### PR TITLE
Replace darcblocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - cd $TRAVIS_BUILD_DIR
 
 script:
-  - make test
+  - make test_fmt test_lint test_goveralls
 
 notifications:
   email: false

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -298,12 +298,18 @@ func (s *Service) tryLoad() error {
 		s.storage.Private = map[string]kyber.Scalar{}
 	}
 	s.collectionDB = map[string]*collectionDB{}
-	// TODO: Do we need this? Could we replace this?
-	/*
-		for _, ch := range s.storage.DarcBlocks {
-			s.getCollection(ch.LatestSkipblock.SkipChainID())
-		}
-	*/
+
+	gas := &skipchain.GetAllSkipchains{}
+	gasr, err := s.skService().GetAllSkipchains(gas)
+	if err != nil {
+		return err
+	}
+
+	allSkipchains := gasr.SkipChains
+	for _, sb := range allSkipchains {
+		s.getCollection(sb.SkipChainID())
+	}
+
 	return nil
 }
 

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"gopkg.in/dedis/cothority.v2"
-	"gopkg.in/dedis/cothority.v2/identity"
 	"gopkg.in/dedis/cothority.v2/skipchain"
 	"gopkg.in/dedis/kyber.v2"
 	"gopkg.in/dedis/kyber.v2/util/key"
@@ -252,11 +251,7 @@ func (s *Service) getCollection(id skipchain.SkipBlockID) *collectionDB {
 	return col
 }
 
-// interface to identity.Service
-func (s *Service) idService() *identity.Service {
-	return s.Service(identity.ServiceName).(*identity.Service)
-}
-
+// interface to skipchain.Service
 func (s *Service) skService() *skipchain.Service {
 	return s.Service(skipchain.ServiceName).(*skipchain.Service)
 }

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -276,6 +276,11 @@ func (s *Service) skService() *skipchain.Service {
 	return s.Service(skipchain.ServiceName).(*skipchain.Service)
 }
 
+// gives us access to the skipchain's database, so we can get blocks by ID
+func (s *Service) db() *skipchain.SkipBlockDB {
+	return s.skService().GetDB()
+}
+
 // saves all skipblocks.
 func (s *Service) save() {
 	s.storage.Lock()

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -52,13 +52,6 @@ type Service struct {
 // than one structure.
 const storageID = "main"
 
-// DarcBlock will be removed
-type DarcBlock struct {
-	sync.Mutex
-	Latest          *Data
-	LatestSkipblock *skipchain.SkipBlock
-}
-
 // Data is the data passed to the Skipchain
 type Data struct {
 	// Root of the merkle tree after applying the transactions to the


### PR DESCRIPTION
This PR should close #8 .
The changes remove DarcBlock struct and replace the reads on it with calls to the skipchains GetLatest function. Writes are removed, since the skipchain layer writes to the corresponding database for us.

In tryLoad, instead of iterating over the LatestSkipblocks in DarcBlocks, we get the all the skipchains from the skipchain service directly via GetAllSkipchains.