### PR TITLE
moving stuff around

### DIFF
--- a/omniledger/collection/proof.go
+++ b/omniledger/collection/proof.go
@@ -3,6 +3,7 @@ package collection
 import (
 	"crypto/sha256"
 	"errors"
+
 	"github.com/dedis/protobuf"
 )
 
@@ -167,9 +168,8 @@ func (p Proof) Values() ([]interface{}, error) {
 	return values, nil
 }
 
-// Private methods
-
-func (p Proof) consistent() bool {
+// Consistent returns true if the proof given is correctly set up.
+func (p Proof) Consistent() bool {
 	if len(p.steps) == 0 {
 		return false
 	}

--- a/omniledger/collection/proof_test.go
+++ b/omniledger/collection/proof_test.go
@@ -346,37 +346,37 @@ func TestProofConsistent(test *testing.T) {
 	key := make([]byte, 8)
 	proof, _ := collection.Get(key).Proof()
 
-	if !(proof.consistent()) {
+	if !(proof.Consistent()) {
 		test.Error("[proof.go]", "[consistent]", "Proof produced by collection is not consistent.")
 	}
 
 	proof.root.Label[0]++
-	if proof.consistent() {
+	if proof.Consistent() {
 		test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering label of root node.")
 	}
 	proof.root.Label[0]--
 
 	proof.root.Values[0][0]++
-	if proof.consistent() {
+	if proof.Consistent() {
 		test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering values of root node.")
 	}
 	proof.root.Values[0][0]--
 
 	proof.root.Children.Left[0]++
-	if proof.consistent() {
+	if proof.Consistent() {
 		test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering label of left child of root node.")
 	}
 	proof.root.Children.Left[0]--
 
 	proof.root.Children.Right[0]++
-	if proof.consistent() {
+	if proof.Consistent() {
 		test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering label of root node.")
 	}
 	proof.root.Children.Right[0]--
 
 	stepsbackup := proof.steps
 	proof.steps = []step{}
-	if proof.consistent() {
+	if proof.Consistent() {
 		test.Error("[proof.go]", "[consistent]", "Proof with no steps is still consisetent.")
 	}
 	proof.steps = stepsbackup
@@ -385,25 +385,25 @@ func TestProofConsistent(test *testing.T) {
 		step := &(proof.steps[index])
 
 		step.Left.Label[0]++
-		if proof.consistent() {
+		if proof.Consistent() {
 			test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering label of one of left steps.")
 		}
 		step.Left.Label[0]--
 
 		step.Right.Label[0]++
-		if proof.consistent() {
+		if proof.Consistent() {
 			test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering label of one of right steps.")
 		}
 		step.Right.Label[0]--
 
 		step.Left.Values[0][0]++
-		if proof.consistent() {
+		if proof.Consistent() {
 			test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering value of one of left steps.")
 		}
 		step.Left.Values[0][0]--
 
 		step.Right.Values[0][0]++
-		if proof.consistent() {
+		if proof.Consistent() {
 			test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering value of one of right steps.")
 		}
 		step.Right.Values[0][0]--
@@ -416,7 +416,7 @@ func TestProofConsistent(test *testing.T) {
 				step.Left.Key = []byte("x")
 			}
 
-			if proof.consistent() {
+			if proof.Consistent() {
 				test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering key of one of left leaf steps.")
 			}
 
@@ -427,13 +427,13 @@ func TestProofConsistent(test *testing.T) {
 			}
 		} else {
 			step.Left.Children.Left[0]++
-			if proof.consistent() {
+			if proof.Consistent() {
 				test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering left child of one of left internal node steps.")
 			}
 			step.Left.Children.Left[0]--
 
 			step.Left.Children.Right[0]++
-			if proof.consistent() {
+			if proof.Consistent() {
 				test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering right child of one of left internal node steps.")
 			}
 			step.Left.Children.Right[0]--
@@ -447,7 +447,7 @@ func TestProofConsistent(test *testing.T) {
 				step.Right.Key = []byte("x")
 			}
 
-			if proof.consistent() {
+			if proof.Consistent() {
 				test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering key of one of right leaf steps.")
 			}
 
@@ -458,20 +458,20 @@ func TestProofConsistent(test *testing.T) {
 			}
 		} else {
 			step.Right.Children.Left[0]++
-			if proof.consistent() {
+			if proof.Consistent() {
 				test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering left child of one of right internal node steps.")
 			}
 			step.Right.Children.Left[0]--
 
 			step.Right.Children.Right[0]++
-			if proof.consistent() {
+			if proof.Consistent() {
 				test.Error("[proof.go]", "[consistent]", "Proof is still consistent after altering right child of one of right internal node steps.")
 			}
 			step.Right.Children.Right[0]--
 		}
 	}
 
-	if !(proof.consistent()) {
+	if !(proof.Consistent()) {
 		test.Error("[proof.go]", "[consistent]", "Proof is not consistent after reversing all the updates, check test.")
 	}
 }

--- a/omniledger/collection/verifiers.go
+++ b/omniledger/collection/verifiers.go
@@ -11,7 +11,7 @@ func (c *Collection) Verify(proof Proof) bool {
 		panic("Verify() called on inconsistent root.")
 	}
 
-	if (proof.root.Label != c.root.label) || !(proof.consistent()) {
+	if (proof.root.Label != c.root.label) || !(proof.Consistent()) {
 		return false
 	}
 

--- a/omniledger/darc/darc_test.go
+++ b/omniledger/darc/darc_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	//	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/dedis/onet.v1/log"
+	"gopkg.in/dedis/onet.v2/log"
 )
 
 func TestDarc(t *testing.T) {

--- a/omniledger/service/messages.go
+++ b/omniledger/service/messages.go
@@ -8,8 +8,6 @@ import (
 	"gopkg.in/dedis/cothority.v2/skipchain"
 	"gopkg.in/dedis/onet.v2"
 	"gopkg.in/dedis/onet.v2/network"
-
-	"github.com/dedis/student_18_omniledger/omniledger/darc"
 )
 
 // We need to register all messages so the network knows how to handle them.
@@ -18,7 +16,6 @@ func init() {
 		&CreateSkipchain{}, &CreateSkipchainResponse{},
 		&SetKeyValue{}, &SetKeyValueResponse{},
 		&GetValue{}, &GetValueResponse{},
-		&Transaction{}, &darc.Signature{},
 	)
 }
 
@@ -108,23 +105,4 @@ type GetValueResponse struct {
 	Signature *[]byte
 	// Proof the value is correct
 	Proof *[]byte
-}
-
-// Transaction is the struct specifying the modifications to the skipchain.
-// Key is the key chosen by the user, Kind is the kind of value to store
-// (e.g. a drac...). The key used in the conode's collection will be
-// Kind ':' Key, in order to maintain key uniqueness across different kinds
-// of values.
-// For a Transaction to be valid, there must exist a path from the master-darc
-// in the genesis block to the SubjectPK in Signature.
-type Transaction struct {
-	Key   []byte
-	Kind  []byte
-	Value []byte
-	// type Signature struct {
-	//     Signature []byte
-	//     Signer SubjectPK
-	// }
-	// The signature is performed on the concatenation of the []bytes
-	Signature darc.Signature
 }

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -6,7 +6,14 @@ import (
 
 	bolt "github.com/coreos/bbolt"
 	"github.com/dedis/student_18_omniledger/omniledger/collection"
+	"github.com/dedis/student_18_omniledger/omniledger/darc"
+	"gopkg.in/dedis/onet.v2/network"
 )
+
+func init() {
+	network.RegisterMessages(&Transaction{},
+		&darc.Signature{})
+}
 
 type collectionDB struct {
 	db         *bolt.DB
@@ -105,4 +112,23 @@ func (c *collectionDB) GetValue(key []byte) (value, sig []byte, err error) {
 // RootHash returns the hash of the root node in the merkle tree.
 func (c *collectionDB) RootHash() []byte {
 	return c.coll.GetRoot()
+}
+
+// Transaction is the struct specifying the modifications to the skipchain.
+// Key is the key chosen by the user, Kind is the kind of value to store
+// (e.g. a drac...). The key used in the conode's collection will be
+// Kind ':' Key, in order to maintain key uniqueness across different kinds
+// of values.
+// For a Transaction to be valid, there must exist a path from the master-darc
+// in the genesis block to the SubjectPK in Signature.
+type Transaction struct {
+	Key   []byte
+	Kind  []byte
+	Value []byte
+	// type Signature struct {
+	//     Signature []byte
+	//     Signer SubjectPK
+	// }
+	// The signature is performed on the concatenation of the []bytes
+	Signature darc.Signature
 }


### PR DESCRIPTION
Maintenance PR:
1. exporting `collection.Proof.Consistent` because it is useful
2. moving `Transaction` structure to `struct.go` because it's not a message
3. changing import in `darc` to point to `onet.v2` instead of `onet.v1`