### PR TITLE
Queue leader

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ skipchains to a new level of performance and functionality. Broadly speaking,
 Omniledger will implement:
 
 1. multiple transactions per block
-2. allow for verification functions that apply to different kinds of data
-3. queuing of transactions at each node and periodical creation of a new
+2. queuing of transactions at each node and periodical creation of a new
 block by the leader
+3. allow for verification functions that apply to different kinds of data
 4. view-change in case the leader fails
 5. sharding of the nodes
 6. inter-shard transactions
@@ -25,31 +25,29 @@ Once we reach point 3 or 4, we'll start porting services over to the new
 omniledger blockchain. As we still want to keep downwards-compatibility, we
 probably will need to create new services.
 
-Currently work on 1. is ongoing
+Work on 1. is finished, work on 2. has been started.
+
+To find the current state of omniledger, use the [README](omniledger/README.md).
 
 ## Sub-tasks
 
-For 1. to work, there are two libraries that need to be done correctly:
-- Darc - to define the access control
-- Collections - to handle the Merkle tree holding all the data
+For 2. to work, we go in steps:
+- implement queueing at the leader
+- implement queues at the followers
+- leader regularly asks followers for new transactions
 
 In addition to this, the ByzCoinX protocol needs to be improved.
 
-### Darc
+### Queueing at the leader
 
-Kelong is looking into Darc and is working on rewriting the policy mechanism
-that allows for AND, OR, NOT and THRESHOLD keywords, to combine signatures from:
-- DarcIdentity - a link to another darc that is allowed to sign
-- Ed25519 - our cryptographic work-horse
-- X509 EC - a more general place holder for cryptographic signatures
+Whenever a leader gets a new transaction request, he puts it in a queue and
+waits for further transactions to come in. After a timeout, the leader collects
+all transactions and proposes them in a new block to the followers who will sign
+the new block by creating a forward-link.
 
-### Collections
+### Queueing at the followers
 
-Raphael did a big cleanup of the collections library to be understandable (putting
-the documentation in the functions) and to follow the go-standard.
-
-Sooner or later we'll need to think of how to hold the tree in a database instead
-of keeping it in memory.
+The followers hold a queue
 
 ### ByzCoinX
 

--- a/omniledger/README.md
+++ b/omniledger/README.md
@@ -1,17 +1,333 @@
 Navigation: [DEDIS](https://github.com/dedis/doc/tree/master/README.md) ::
-[Cothority](../README.md) ::
-[Building Blocks](../doc/BuildingBlocks.md) ::
+[Cothority](https://github.com/dedis/cothority/tree/master/README.md) ::
+[Building Blocks](https://github.com/dedis/cothority/tree/master/BuildingBlocks.md) ::
 Omniledger
 
-# Omniledger implementation
+# OmniLedger
 
 This implementation of Omniledger has its goal to implement the protocol
 described in the [Omniledger Paper](https://eprint.iacr.org/2017/406.pdf).
 As the paper is only describing the network interaction and very few of the
-details of how the transactions themselves are handled, we define the
-following details:
+details of how the transactions themselves are handled, we will include
+them as seem fit.
 
-- multiple transactions per block
-- key/value storage is protected by verification functions
-- queueing of transactions at the nodes and collection by the leader
-- view-change of the leader if he stalls
+This document describes the part of omniledger that are implemented and how to
+use them. It should grow over time as more parts of the system are implemented.
+
+## Overview
+
+Broadly speaking, omniledger will implement:
+
+1. multiple transactions per block
+2. queuing of transactions at each node and periodical creation of a new
+block by the leader
+3. allow for verification functions that apply to different kinds of data
+4. view-change in case the leader fails
+5. sharding of the nodes
+6. inter-shard transactions
+
+1-4 are issues that should've been included in skipchains for a long time, but
+never got in. Only 5-6 are 'real' omniledger improvements as described in the
+[Omniledger Paper](https://eprint.iacr.org/2017/406.pdf).
+
+# Structure Definitions
+
+Following is an overview of the most important structures defined in Omniledger
+and how they can be described using protobuf. For each protobuf description we
+give a short overview of the different fields and how they work together.
+
+## Darc
+
+Package darc in most of our projects we need some kind of access control to
+protect resources. Instead of having a simple password or public key for
+authentication, we want to have access control that can be: evolved with a
+threshold number of keys be delegated. So instead of having a fixed list of
+identities that are allowed to access a resource, the goal is to have an
+evolving description of who is allowed or not to access a certain resource.
+
+A darc has the following format:
+
+```
+message Darc {
+	// Version should be monotonically increasing over the evolution of a Darc.
+	uint64 Version = 1;
+	// Description is a free-form field that can hold any data as required by the user.
+	// Darc itself will never depend on any of the data in here.
+	bytes Description = 2;
+	// BaseID is the ID of the first darc of this Series
+	bytes BaseID = 3;
+	// Rules map an action to an expression.
+	Rules Rules = 4;
+	// Signature is calculated over the protobuf representation of [Rules, Version, Description]
+	// and needs to be created by an Owner from the previous valid Darc.
+	bytes Signature = 5;
+}
+
+message Rule {
+  map<string, bytes> Rules = 1;
+}
+```
+
+The primary type is a darc. Which contains a set of rules that what type of
+permission are granted for any identity. A darc can be updated by performing an
+evolution.  That is, the identities that have the "evolve" permission in the
+old darc can creates a signature that signs off the new darc. Evolutions can be
+performed any number of times, which creates a chain of darcs, also known as a
+path. A path can be verified by starting at the oldest darc (also known as the
+base darc), walking down the path and verifying the signature at every step.
+
+As mentioned before, it is possible to perform delegation. For example, instead
+of giving the "evolve" permission to (public key) identities, we can give it to
+other darcs. For example, suppose the newest darc in some path, let's called it
+darc_A, has the "evolve" permission set to true for another darc---darc_B, then
+darc_B is allowed to evolve the path.
+
+Of course, we do not want to have static rules that allows only a single
+signer.  Our darc implementation supports an expression language where the user
+can use logical operators to specify the rule.  For exmple, the expression
+"darc:a & ed25519:b | ed25519:c" means that "darc:a" and at least one of
+"ed25519:b" and "ed25519:c" must sign. For more information please see the
+expression package.
+
+## Transactions
+
+A block in omniledger contains zero or more transactions. Each transaction
+
+A transaction in Omniledger has the following format:
+
+```
+message Transaction {
+  bytes Key = 1;
+  bytes Kind = 2;
+  bytes Value = 3;
+  enum Operation {
+    ADD = 0;
+    UPDATE = 1;
+    DELETE = 2;
+  }
+  Operation Operation = 4;
+  DarcSignature Signature = 5;
+  boolean Valid = 6;
+}
+```
+
+The *Key* is created similar to the way Ethereum creates its addresses and is
+always 64 bytes long. The lower 32 bytes are filled with the BaseID of the
+Darc that allows the Key/Kind/Value triplet to be stored in omniledger.
+The upper 32 bytes are a nonce that needs to be unique for unique triplets,
+but that doesn't need to be monotonic or increasing.
+
+The *Kind* is the hash of the precompiled smart contract that will be executed
+to verify the triplet is valid. Some examples of such contracts are:
+
+- create a new Darc
+- Administer omniledger:
+  - Add or remove nodes
+  - Change the time between two blocks
+- Onchain-secrets:
+  - Create a write request
+  - Create a read request
+- Evoting:
+  - Setting up a new election
+  - Casting a vote
+  - Requesting mix
+  - Requesting decryption
+- PoP:
+  - Create a new party
+
+The *Value* is any slice of bytes that will be interpreted correctly by the
+smart contract.
+
+The *Operation* defines whether this is a new triplet, an update to an existing one
+or whether it deletes the triplet. The smart contract has to take into account
+the different Operation requested.
+
+The *Signature* is created on the darc-action with regard to the Transaction
+and needs to be verifiable by all nodes.
+
+The *Valid* field is filled in by the leader to indicate whether this transaction
+will be included in the system state or not. Every node needs to make sure that
+valid transactions are correct and that invalid transactions are indeed incorrect.
+
+## Proof
+
+The proof in omniledger proves the absence or the presence of a key in the state
+of the given skipchain. If the key is present, the proof also contains the kind
+and the value of that key.
+
+To verify the proof, all the verifier needs is the skipchain-ID of where the
+key is supposed to be stored. The proof has three parts:
+
+1. _InclusionProof_ proofs the presence or absence of the key. In case of
+the key being present, the value is included in the proof.
+2. _Latest_ is used to verify the merkle tree root used in the collection-proof
+is stored in the latest skipblock.
+3. _Links_ proves that the latest skipblock is part of the skipchain.
+
+So the protobuf-definition of a proof is the following:
+
+```
+message Proof {
+	// InclusionProof is the deserialized InclusionProof
+	collection.Proof InclusionProof = 1;
+	// Providing the latest skipblock to retrieve the Merkle tree root.
+	skipchain.SkipBlock Latest = 2;
+	// Proving the path to the latest skipblock. The first ForwardLink has an
+	// empty-sliced `From` and the genesis-block in `To`, together with the
+	// roster of the genesis-block in the `NewRoster`.
+	repeated skipchain.ForwardLink Links = 3;
+}
+
+message skipchain.SkipBlock{
+  // Many omitted fields
+  bytes Data = 9;
+  // Other omitted fields
+}
+
+message skipchain.ForwardLink{
+  // From - where this forward link comes from
+  bytes From = 1;
+  // To - where this forward link points to
+  bytes To = 2;
+  // NewRoster is only set to non-nil if the From block has a
+  // different roster from the To-block.
+  onet.Roster NewRoster = 3;
+  // Signature is calculated on the
+  // sha256(From.Hash()|To.Hash()|NewRoster)
+  // In the case that NewRoster is nil, the signature is
+  // calculated on the sha256(From.Hash()|To.Hash())
+  byzcoinx.FinalSignature Signature = 4;
+}
+
+```
+
+During verification, the verifier then can do the following:
+
+1. Verify the inclusion proof of the key in the merkle tree root of the collection.
+This is described in the [colleciton](#collection) section.
+2. Verify the merkle tree root in the InclusionProof is the same as the one
+given in the latest skipblock
+3. Verify the Links are a valid chain from the genesis block to the latest block.
+The first forward link points to the genesis block to give the roster to the
+verifier, so the verifier only needs the skipchain-id and doesn't need to have
+the genesis block.
+
+## Collection
+
+The collection is a Merkle-tree based data structure to securely and
+verifiably store key / value associations on untrusted nodes. The library
+in this package focuses on ease of use and flexibility, allowing to easily
+develop applications ranging from simple client-server storage to fully
+distributed and decentralized ledgers with minimal bootstrapping time.
+
+# Usage and Comments
+
+## Transaction Queue and Block Generation
+
+This part of the document describes the technical details of the design and
+implementation of transaction queue and block generation for OmniLedger. The
+assumption is that the leader will not fail. We will implement view-change in
+the future, starting by eliminating stop-failure and then byzantine-failure.
+Further, we assume there exists a maximum block size of B bytes. Transaction
+Queue A transaction is similar to what is defined above, namely a key/kind/value
+triplet and a signature of the requester (client). However, for bookkeeping
+purposes, we add a private field: "status". A status can be one of three
+states: "New" | "Verified" | "Submitted". The transaction request message is
+the same as the Transaction struct above, e.g.
+
+```
+message TransactionRequest {
+  Transaction Transaction = 1;
+}
+```
+
+TransactionRequest can be sent to any conode. The client should send it to
+multiple conodes if it suspects that some of the conode might fail or are
+malicious. On the conode, it will store all transactions that it received, in a
+queue in memory, with the initial state being "New". We use a slice with a mutex
+as the implementation for the queue. If the total size of the queue exceeds B
+bytes (we may need to adjust this to support a large backlog), then the conode
+responds to the client with a failure message, otherwise a success message. The
+client should not see the success message as an indication that the transaction
+is included in the block, but that the transaction is received and may be
+accepted into a block. We do not attempt to check whether the transaction is
+valid at this point because the conode’s darc database might not be up-to-date,
+for example if it just came back online.  
+
+### Block Generation
+
+The poll method is inspired by the
+beta synchroniser, where the leader sends a message, e.g.
+
+```
+message PollTxRequest{
+  bytes LatestBlockID = 1;
+}
+```
+
+down the communication tree, and then every
+node will respond with a type
+
+```
+message PollTxResponse {
+  repeated Transaction Txs = 1;
+}
+```
+
+The transactions are combined on the subleader nodes.
+
+However, before sending the `PollTxResponse` message, the conodes must check that
+the state of omniledger does include the transactions in the latest block
+given by the id in `PollTxRequest`. If the state is not
+up-to-date, then the nodes must do an update to ensure it is. Then, the nodes
+verify `Transaction.Signature` to make sure that all transaction in their queue are
+valid. The valid transactions are marked as "Verified" and the bad transactions
+are dropped and a message is printed to the audit log. Finally, the transactions
+with the "Verified" flag are sent to the leader in the `PollTxResponse` message.
+These transactions are marked as "Submitted". The `PollTxResponse` message should
+not be larger than B bytes.
+
+Upon receiving all the `PollTxResponse` message, the leader does the following:
+- remove duplicates
+- verify signature
+- sort the transactions in a random but deterministic way
+- go through the list of transactions, and for each transaction mark if it
+applies correctly to the state updated with previous valid transactions
+
+Then the leader creates the block and then sends it to the conodes to cosign, e.g.
+
+```
+message BlockProposal {
+  Data Data = 1;
+}
+```
+
+The conodes run the same checks and need to make sure that the transactions are
+in the same state as marked by the leader. If this is the case, they sign the
+hash of the proposed block.
+
+The new block, with a collective signature, is propagated back to all nodes.
+Then every node updates their queue and removes the transactions that are in the
+new block. For the transactions that were not added to the new block, they need
+to be moved to the front of the queue and marked as "New" because the state
+of omniledger may have changed and the old transactions may become invalid. All the
+"Verified" transactions must also be changed back to "New".
+
+### Additional blocks
+
+What we described above is how to generate a single block, how do we run it
+multiple times? A simple solution would be for the leader to send a
+`PollTxRequest` after every new block is generated. However, it results in a lot
+of wasted messages if there are very little or no transactions. We can attempt
+to implement the simplest technique first and then try to optimise it later. For
+example, a slightly better version would be to add some delay when the blocks
+are getting smaller. But this is only a heuristic because the leader does not
+know how many transactions are in the queues of the non-root nodes.
+
+Another option would be that each node sends _one_ message to the leader if it
+has not-included transactions. This could happen when:
+- the queue has been empty and a first transaction comes in
+- a new block has been accepted, but not all transaction of the queue are in
+that block
+This would be halfway between only depending on the leader and sending _all_
+transactions to the leader.

--- a/omniledger/app.go
+++ b/omniledger/app.go
@@ -104,11 +104,11 @@ func set(c *cli.Context) error {
 		Key:   []byte(key),
 		Value: []byte(value),
 	}
-	resp, err := service.NewClient().SetKeyValue(group.Roster, scid, tx)
+	_, err = service.NewClient().SetKeyValue(group.Roster, scid, tx)
 	if err != nil {
 		return errors.New("couldn't set new key/value pair: " + err.Error())
 	}
-	log.Infof("Successfully set new key/value pair in block: %x", resp.SkipblockID)
+	log.Info("Submitted new key/value")
 	return nil
 }
 

--- a/omniledger/collection/manipulators_test.go
+++ b/omniledger/collection/manipulators_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestManipulatorsAdd(test *testing.T) {
+	if testing.Short() {
+		test.Skip("using race this takes a long time")
+	}
 	ctx := testCtx("[manipulators.go]", test)
 
 	stake64 := Stake64{}
@@ -79,6 +82,9 @@ func TestManipulatorsAdd(test *testing.T) {
 }
 
 func TestManipulatorsSet(test *testing.T) {
+	if testing.Short() {
+		test.Skip("using race this takes a long time")
+	}
 	ctx := testCtx("[manipulators.go]", test)
 
 	stake64 := Stake64{}
@@ -197,6 +203,9 @@ func TestManipulatorsSetField(test *testing.T) {
 }
 
 func TestManipulatorsRemove(test *testing.T) {
+	if testing.Short() {
+		test.Skip("using race this takes a long time")
+	}
 	ctx := testCtx("[manipulators.go]", test)
 
 	collection := New()

--- a/omniledger/service/messages.go
+++ b/omniledger/service/messages.go
@@ -76,10 +76,6 @@ type SetKeyValue struct {
 type SetKeyValueResponse struct {
 	// Version of the protocol
 	Version Version
-	// Timestamp is milliseconds since the unix epoch (1/1/1970, 12am UTC)
-	Timestamp *int64
-	// Skipblock ID is the hash of the block where the value is stored
-	SkipblockID *skipchain.SkipBlockID
 }
 
 // GetProof returns the proof that the given key is in the collection.

--- a/omniledger/service/proof_test.go
+++ b/omniledger/service/proof_test.go
@@ -35,19 +35,19 @@ func TestVerify(t *testing.T) {
 	p, err := NewProof(s.c, s.s, s.genesis.Hash, s.key)
 	require.Nil(t, err)
 	require.True(t, p.InclusionProof.Match())
-	require.Nil(t, p.Verify(s.genesis))
+	require.Nil(t, p.Verify(s.genesis.SkipChainID()))
 	key, values, err := p.KeyValue()
 	require.Nil(t, err)
 	require.Equal(t, s.key, key)
 	require.Equal(t, s.value, values[0])
 
-	require.Equal(t, ErrorVerifySkipchain, p.Verify(s.genesis2))
+	require.Equal(t, ErrorVerifySkipchain, p.Verify(s.genesis2.SkipChainID()))
 
 	p.Latest.Data, err = network.Marshal(&Data{
 		MerkleRoot: getSBID("123"),
 	})
 	require.Nil(t, err)
-	require.Equal(t, ErrorVerifyMerkleRoot, p.Verify(s.genesis))
+	require.Equal(t, ErrorVerifyMerkleRoot, p.Verify(s.genesis.SkipChainID()))
 }
 
 type sc struct {
@@ -91,7 +91,7 @@ func createSC(t *testing.T) (s sc) {
 
 	s.key = []byte("key")
 	s.value = []byte("value")
-	s.c.Store(s.key, s.value, nil)
+	s.c.Store(&Transaction{Key: s.key, Value: s.value})
 
 	s.genesis = skipchain.NewSkipBlock()
 	s.genesis.Roster, s.genesisPrivs = genRoster(1)

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -1,27 +1,31 @@
 package service
 
 import (
+	"bytes"
 	"testing"
+	"time"
 
-	"github.com/dedis/cothority/ocs/darc"
-	"github.com/dedis/onet/network"
+	"github.com/dedis/student_18_omniledger/omniledger/darc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dedis/cothority.v2/skipchain"
 	"gopkg.in/dedis/kyber.v2/suites"
 	"gopkg.in/dedis/onet.v2"
 	"gopkg.in/dedis/onet.v2/log"
+	"gopkg.in/dedis/onet.v2/network"
 )
 
 var tSuite = suites.MustFind("Ed25519")
 
 func TestMain(m *testing.M) {
+	waitQueueing = 100 * time.Millisecond
 	log.MainTest(m)
 }
 
 func TestService_CreateSkipchain(t *testing.T) {
 	s := newSer(t, 0)
 	defer s.local.CloseAll()
+	defer closeQueues(s.local)
 	resp, err := s.service.CreateSkipchain(&CreateSkipchain{
 		Version: 0,
 		Roster:  *s.roster,
@@ -45,6 +49,7 @@ func TestService_CreateSkipchain(t *testing.T) {
 func TestService_AddKeyValue(t *testing.T) {
 	s := newSer(t, 1)
 	defer s.local.CloseAll()
+	defer closeQueues(s.local)
 
 	akvresp, err := s.service.SetKeyValue(&SetKeyValue{
 		Version: 0,
@@ -62,23 +67,78 @@ func TestService_AddKeyValue(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, akvresp)
 	require.Equal(t, CurrentVersion, akvresp.Version)
-	require.NotNil(t, akvresp.Timestamp)
-	require.NotNil(t, akvresp.SkipblockID)
+
+	key2 := []byte("second")
+	value2 := []byte("value2")
+	akvresp, err = s.service.SetKeyValue(&SetKeyValue{
+		Version:     CurrentVersion,
+		SkipchainID: s.sb.SkipChainID(),
+		Transaction: Transaction{
+			Key:   key2,
+			Kind:  []byte("testKind"),
+			Value: value2,
+		},
+	})
+	require.Nil(t, err)
+	require.NotNil(t, akvresp)
+	require.Equal(t, CurrentVersion, akvresp.Version)
+
+	pairs := map[string][]byte{string(s.key): s.value, string(key2): value2}
+
+	for i := 0; i < 2; i++ {
+		if i == 1 {
+			// Now read the key/values from a new service
+			log.Lvl1("Recreate services and fetch keys again")
+			s.service.tryLoad()
+		}
+		for key, value := range pairs {
+			for {
+				time.Sleep(2 * waitQueueing)
+				pr, err := s.service.GetProof(&GetProof{
+					Version: CurrentVersion,
+					ID:      s.sb.SkipChainID(),
+					Key:     []byte(key),
+				})
+				if err != nil {
+					continue
+				}
+				require.Equal(t, CurrentVersion, pr.Version)
+				require.Nil(t, pr.Proof.Verify(s.sb.SkipChainID()))
+				if pr.Proof.InclusionProof.Match() {
+					_, vs, err := pr.Proof.KeyValue()
+					require.Nil(t, err)
+					require.Equal(t, 0, bytes.Compare(value, vs[0]))
+					break
+				}
+			}
+		}
+	}
 }
 
 func TestService_GetProof(t *testing.T) {
 	s := newSer(t, 2)
 	defer s.local.CloseAll()
+	defer closeQueues(s.local)
 
-	rep, err := s.service.GetProof(&GetProof{
-		Version: CurrentVersion,
-		ID:      s.sb.SkipChainID(),
-		Key:     s.key,
-	})
-	require.Nil(t, err)
+	var rep *GetProofResponse
+	var i int
+	for i = 0; i < 10; i++ {
+		time.Sleep(2 * waitQueueing)
+		var err error
+		rep, err = s.service.GetProof(&GetProof{
+			Version: CurrentVersion,
+			ID:      s.sb.SkipChainID(),
+			Key:     s.key,
+		})
+		require.Nil(t, err)
+		if rep.Proof.InclusionProof.Match() {
+			break
+		}
+	}
+	require.NotEqual(t, 10, i, "didn't get proof in time")
 	key, values, err := rep.Proof.KeyValue()
 	require.Nil(t, err)
-	require.Nil(t, rep.Proof.Verify(s.sb))
+	require.Nil(t, rep.Proof.Verify(s.sb.SkipChainID()))
 	require.Equal(t, s.key, key)
 	require.Equal(t, s.value, values[0])
 
@@ -88,7 +148,7 @@ func TestService_GetProof(t *testing.T) {
 		Key:     append(s.key, byte(0)),
 	})
 	require.Nil(t, err)
-	require.Nil(t, rep.Proof.Verify(s.sb))
+	require.Nil(t, rep.Proof.Verify(s.sb.SkipChainID()))
 	key, values, err = rep.Proof.KeyValue()
 	require.NotNil(t, err)
 }
@@ -111,7 +171,7 @@ func newSer(t *testing.T, step int) *ser {
 		value: []byte("anyvalue"),
 	}
 	s.hosts, s.roster, _ = s.local.GenTree(5, true)
-	s.service = s.local.GetServices(s.hosts, lleapID)[0].(*Service)
+	s.service = s.local.GetServices(s.hosts, omniledgerID)[0].(*Service)
 	s.darc = &darc.Darc{}
 
 	for i := 0; i < step; i++ {
@@ -141,7 +201,15 @@ func newSer(t *testing.T, step int) *ser {
 				},
 			})
 			require.Nil(t, err)
+			time.Sleep(4 * waitQueueing)
 		}
 	}
 	return s
+}
+
+func closeQueues(local *onet.LocalTest) {
+	for _, server := range local.Servers {
+		services := local.GetServices([]*onet.Server{server}, omniledgerID)
+		close(services[0].(*Service).CloseQueues)
+	}
 }


### PR DESCRIPTION
First implementation of having a queue in the leader. The first request will start a go-routine and all further requests will only add transactions to the queue. Once the leader created a new block, it will ask all nodes to integrate that block into their collection.

This is work-in-progress, but if @pablo-lo manages to work on this, it would be great.

Closes #9
Closes #10