### PR TITLE
Insert tentatively

### DIFF
--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -92,7 +92,7 @@ func (s *Service) CreateSkipchain(req *CreateSkipchain) (
 
 	kp := key.NewKeyPair(cothority.Suite)
 
-	tmpColl := collection.New(collection.Data{}, collection.Data{})
+	tmpColl := collection.New(collection.Data{})
 	key := getKey(&req.Transaction)
 	tmpColl.Add(key, req.Transaction.Value)
 
@@ -170,7 +170,7 @@ func (s *Service) SetKeyValue(req *SetKeyValue) (*SetKeyValueResponse, error) {
 
 	coll := s.getCollection(req.SkipchainID)
 	key := getKey(&req.Transaction)
-	if _, _, err := coll.GetValue(key); err == nil {
+	if _, err := coll.GetValue(key); err == nil {
 		return nil, errors.New("cannot overwrite existing value")
 	}
 
@@ -233,14 +233,13 @@ func (s *Service) GetValue(req *GetValue) (*GetValueResponse, error) {
 	}
 
 	key := append(append(req.Kind, []byte(":")...), req.Key...)
-	value, sig, err := s.getCollection(req.SkipchainID).GetValue(key)
+	value, err := s.getCollection(req.SkipchainID).GetValue(key)
 	if err != nil {
 		return nil, errors.New("couldn't get value for key: " + err.Error())
 	}
 	return &GetValueResponse{
-		Version:   CurrentVersion,
-		Value:     &value,
-		Signature: &sig,
+		Version: CurrentVersion,
+		Value:   &value,
 	}, nil
 }
 

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -94,11 +94,7 @@ func (s *Service) CreateSkipchain(req *CreateSkipchain) (
 
 	tmpColl := collection.New(collection.Data{}, collection.Data{})
 	key := getKey(&req.Transaction)
-	sigBuf, err := network.Marshal(&req.Transaction.Signature)
-	if err != nil {
-		return nil, errors.New("Couldn't marshal Signature: " + err.Error())
-	}
-	tmpColl.Add(key, req.Transaction.Value, sigBuf)
+	tmpColl.Add(key, req.Transaction.Value)
 
 	mr := tmpColl.GetRoot()
 	data := &Data{
@@ -132,7 +128,7 @@ func (s *Service) CreateSkipchain(req *CreateSkipchain) (
 		LatestSkipblock: ssbReply.Latest,
 	}
 
-	err = s.getCollection(skID).Store(key, req.Transaction.Value, sigBuf)
+	err = s.getCollection(skID).Store(key, req.Transaction.Value)
 	if err != nil {
 		return nil, errors.New(
 			"error while storing in collection: " + err.Error())
@@ -177,17 +173,13 @@ func (s *Service) SetKeyValue(req *SetKeyValue) (*SetKeyValueResponse, error) {
 	if _, _, err := coll.GetValue(key); err == nil {
 		return nil, errors.New("cannot overwrite existing value")
 	}
-	sigBuf, err := network.Marshal(&req.Transaction.Signature)
-	if err != nil {
-		return nil, errors.New("Couldn't marshal Signature: " + err.Error())
-	}
 
 	// Store the pair in a copy of the collection to get the root hash.
 	// Once the block is accepted by the cothority, we store it in the real
 	// collectionBD.
 	var collCopy collection.Collection
 	collCopy = s.getCollection(req.SkipchainID).coll
-	collCopy.Add(key, req.Transaction.Value, sigBuf)
+	collCopy.Add(key, req.Transaction.Value)
 	mr := collCopy.GetRoot()
 	data := &Data{
 		MerkleRoot:   mr,
@@ -214,7 +206,7 @@ func (s *Service) SetKeyValue(req *SetKeyValue) (*SetKeyValueResponse, error) {
 
 	// Now we know the block is accepted, so we can apply the the Transaction
 	// to our collectionDB.
-	err = coll.Store(key, req.Transaction.Value, sigBuf)
+	err = coll.Store(key, req.Transaction.Value)
 	if err != nil {
 		return nil, errors.New(
 			"error while storing in collection: " + err.Error())

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -49,17 +49,11 @@ func (c *collectionDB) loadAll() {
 	})
 }
 
-func (c *collectionDB) Store(key, value, sig []byte) error {
-	c.coll.Add(key, value, sig)
+func (c *collectionDB) Store(key, value []byte) error {
+	c.coll.Add(key, value)
 	err := c.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(c.bucketName))
 		if err := bucket.Put(key, value); err != nil {
-			return err
-		}
-		keysig := make([]byte, len(key)+3)
-		copy(keysig, key)
-		keysig = append(keysig, []byte("sig")...)
-		if err := bucket.Put(keysig, sig); err != nil {
 			return err
 		}
 		return nil

--- a/omniledger/service/struct_test.go
+++ b/omniledger/service/struct_test.go
@@ -24,12 +24,11 @@ func TestCollectionDBStrange(t *testing.T) {
 	require.Nil(t, err)
 
 	cdb := newCollectionDB(db, "coll1")
-	err = cdb.Store([]byte("first"), []byte("value"), []byte("mysig"))
+	err = cdb.Store([]byte("first"), []byte("value"))
 	require.Nil(t, err)
-	value, sig, err := cdb.GetValue([]byte("first"))
+	value, err := cdb.GetValue([]byte("first"))
 	require.Nil(t, err)
 	require.Equal(t, []byte("value"), value)
-	require.Equal(t, []byte("mysig"), sig)
 }
 
 func TestCollectionDB(t *testing.T) {
@@ -45,22 +44,20 @@ func TestCollectionDB(t *testing.T) {
 
 	cdb := newCollectionDB(db, "coll1")
 	pairs := map[string]string{}
-	mysig := []byte("mysignature")
 	for i := 0; i < kvPairs; i++ {
 		pairs[fmt.Sprintf("Key%d", i)] = fmt.Sprintf("value%d", i)
 	}
 
 	// Store all key/value pairs
 	for k, v := range pairs {
-		require.Nil(t, cdb.Store([]byte(k), []byte(v), mysig))
+		require.Nil(t, cdb.Store([]byte(k), []byte(v)))
 	}
 
 	// Verify it's all there
 	for k, v := range pairs {
-		stored, sig, err := cdb.GetValue([]byte(k))
+		stored, err := cdb.GetValue([]byte(k))
 		require.Nil(t, err)
 		require.Equal(t, v, string(stored))
-		require.Equal(t, mysig, sig)
 	}
 
 	// Get a new db handler
@@ -68,7 +65,7 @@ func TestCollectionDB(t *testing.T) {
 
 	// Verify it's all there
 	for k, v := range pairs {
-		stored, _, err := cdb2.GetValue([]byte(k))
+		stored, err := cdb2.GetValue([]byte(k))
 		require.Nil(t, err)
 		require.Equal(t, v, string(stored))
 	}

--- a/omniledger/service/struct_test.go
+++ b/omniledger/service/struct_test.go
@@ -31,6 +31,24 @@ func TestCollectionDBStrange(t *testing.T) {
 	require.Equal(t, []byte("value"), value)
 }
 
+func TestCollectionDBtryHash(t *testing.T) {
+	tmpDB, err := ioutil.TempFile("", "tmpDB")
+	require.Nil(t, err)
+	tmpDB.Close()
+	defer os.Remove(tmpDB.Name())
+
+	db, err := bolt.Open(tmpDB.Name(), 0600, nil)
+	require.Nil(t, err)
+
+	cdb := newCollectionDB(db, "coll1")
+	mrTrial := cdb.tryHash([]byte("first"), []byte("value"))
+	_, err = cdb.GetValue([]byte("first"))
+	require.EqualError(t, err, "no match found")
+	cdb.Store([]byte("first"), []byte("value"))
+	mrReal := cdb.RootHash()
+	require.Equal(t, mrTrial, mrReal)
+}
+
 func TestCollectionDB(t *testing.T) {
 	kvPairs := 16
 


### PR DESCRIPTION
**THIS PR IS SUPERCEDED BY PR #34**
The proposed changes aim to accomplish the following and thus resolve #9:
- The signature of a Transaction is no longer stored in the collectionDB.
Since the Transaction (and thus its signature) is stored in the sikpblock,
there is no point in storing it a second time.
- In order to propose a block to the skipchain, we must know the merkle root
of the collectionDB after the application of the transactions which will be 
stored in the block. However, we should only apply those transactions to the
collectionDB once the block is accepted by the skipchain. Therefore, this
PR adds a tryHash function which returns the merkle root of the collectionDB
after applying a transaction, but undoes the transaction.
A testcase has been added for this functionality.