### PR TITLE
Insert tentatively with queue

### DIFF
--- a/omniledger/app.go
+++ b/omniledger/app.go
@@ -108,7 +108,7 @@ func set(c *cli.Context) error {
 	if err != nil {
 		return errors.New("couldn't set new key/value pair: " + err.Error())
 	}
-	log.Infof("Successfully set new key/value pair in block: %x", resp.SkipblockID)
+	log.Infof("Submitted new key/value - length of queue is: %d", resp.QueueLength)
 	return nil
 }
 

--- a/omniledger/collection/manipulators_test.go
+++ b/omniledger/collection/manipulators_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestManipulatorsAdd(test *testing.T) {
+	if testing.Short() {
+		test.Skip("using race this takes a long time")
+	}
 	ctx := testCtx("[manipulators.go]", test)
 
 	stake64 := Stake64{}
@@ -79,6 +82,9 @@ func TestManipulatorsAdd(test *testing.T) {
 }
 
 func TestManipulatorsSet(test *testing.T) {
+	if testing.Short() {
+		test.Skip("using race this takes a long time")
+	}
 	ctx := testCtx("[manipulators.go]", test)
 
 	stake64 := Stake64{}
@@ -197,6 +203,9 @@ func TestManipulatorsSetField(test *testing.T) {
 }
 
 func TestManipulatorsRemove(test *testing.T) {
+	if testing.Short() {
+		test.Skip("using race this takes a long time")
+	}
 	ctx := testCtx("[manipulators.go]", test)
 
 	collection := New()

--- a/omniledger/service/api_test.go
+++ b/omniledger/service/api_test.go
@@ -1,35 +1,31 @@
-package service_test
+package service
 
 import (
 	"testing"
+	"time"
 
-	"gopkg.in/dedis/kyber.v2/suites"
-
-	// We need to include the service so it is started.
-	"github.com/dedis/student_18_omniledger/omniledger/service"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dedis/cothority.v2"
 	"gopkg.in/dedis/onet.v2"
 )
 
-var tSuite = suites.MustFind("Ed25519")
-
 func TestClient_GetProof(t *testing.T) {
 	l := onet.NewTCPTest(cothority.Suite)
 	_, roster, _ := l.GenTree(3, true)
 	defer l.CloseAll()
-	c := service.NewClient()
-	csr, err := c.CreateSkipchain(roster, service.Transaction{Key: []byte{1}})
+	c := NewClient()
+	csr, err := c.CreateSkipchain(roster, Transaction{Key: []byte{1}})
 	require.Nil(t, err)
 
 	key := []byte{1, 2, 3, 4}
 	value := []byte{5, 6, 7, 8}
 	_, err = c.SetKeyValue(roster, csr.Skipblock.SkipChainID(),
-		service.Transaction{
+		Transaction{
 			Key:   key,
 			Value: value,
 		})
 	require.Nil(t, err)
+	time.Sleep(4 * waitQueueing)
 
 	p, err := c.GetProof(roster, csr.Skipblock.SkipChainID(), key)
 	require.Nil(t, err)

--- a/omniledger/service/api_test.go
+++ b/omniledger/service/api_test.go
@@ -25,10 +25,17 @@ func TestClient_GetProof(t *testing.T) {
 			Value: value,
 		})
 	require.Nil(t, err)
-	time.Sleep(4 * waitQueueing)
 
-	p, err := c.GetProof(roster, csr.Skipblock.SkipChainID(), key)
-	require.Nil(t, err)
+	var p *GetProofResponse
+	for {
+		time.Sleep(4 * waitQueueing)
+		var err error
+		p, err = c.GetProof(roster, csr.Skipblock.SkipChainID(), key)
+		require.Nil(t, err)
+		if p.Proof.InclusionProof.Match() {
+			break
+		}
+	}
 	require.Nil(t, p.Proof.Verify(csr.Skipblock))
 	k, vs, err := p.Proof.KeyValue()
 	require.Nil(t, err)

--- a/omniledger/service/messages.go
+++ b/omniledger/service/messages.go
@@ -76,10 +76,8 @@ type SetKeyValue struct {
 type SetKeyValueResponse struct {
 	// Version of the protocol
 	Version Version
-	// Timestamp is milliseconds since the unix epoch (1/1/1970, 12am UTC)
-	Timestamp *int64
-	// Skipblock ID is the hash of the block where the value is stored
-	SkipblockID *skipchain.SkipBlockID
+	// QueueLength indicates how many transactions are waiting
+	QueueLength int
 }
 
 // GetProof returns the proof that the given key is in the collection.

--- a/omniledger/service/proof_test.go
+++ b/omniledger/service/proof_test.go
@@ -91,7 +91,7 @@ func createSC(t *testing.T) (s sc) {
 
 	s.key = []byte("key")
 	s.value = []byte("value")
-	s.c.Store(s.key, s.value, nil)
+	s.c.Store(&Transaction{Key: s.key, Value: s.value})
 
 	s.genesis = skipchain.NewSkipBlock()
 	s.genesis.Roster, s.genesisPrivs = genRoster(1)

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -95,7 +95,6 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, ts 
 
 	if scID.IsNull() {
 		// For a genesis block, we create a throwaway collection.
-		log.Print("creating new collection")
 		c = collection.New(&collection.Data{}, &collection.Data{})
 
 		sb = skipchain.NewSkipBlock()
@@ -105,7 +104,6 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, ts 
 	} else {
 		// For further blocks, we create a clone of the collection - this is
 		// TODO: not very memory-friendly - we need to use some kind of transactions.
-		log.Printf("Adding a block to %x", scID)
 		c = s.getCollection(scID).coll.Clone()
 
 		sbLatest, err := s.db().GetLatest(s.db().GetByID(scID))
@@ -182,7 +180,6 @@ func (s *Service) updateCollection(msg network.Message) {
 	// TODO: wrap this in a transaction
 	cdb := s.getCollection(sb.SkipChainID())
 	for _, t := range data.Transactions {
-		log.Printf("Storing %x/%x in %x", t.Key, t.Value, sb.SkipChainID())
 
 		err = cdb.Store(t)
 		if err != nil {
@@ -222,7 +219,6 @@ func (s *Service) GetProof(req *GetProof) (resp *GetProofResponse, err error) {
 	if req.Version != CurrentVersion {
 		return nil, errors.New("version mismatch")
 	}
-	log.Printf("Getting %x from sc %x - %p", req.Key, req.ID, s.getCollection(req.ID))
 	latest, err := s.db().GetLatest(s.db().GetByID(req.ID))
 	if err != nil {
 		return
@@ -242,7 +238,6 @@ func (s *Service) getCollection(id skipchain.SkipBlockID) *collectionDB {
 	idStr := fmt.Sprintf("%x", id)
 	col := s.collectionDB[idStr]
 	if col == nil {
-		log.Printf("%s creates new for %x", s.ServerIdentity(), id)
 		db, name := s.GetAdditionalBucket([]byte(idStr))
 		s.collectionDB[idStr] = newCollectionDB(db, name)
 		return s.collectionDB[idStr]

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -66,6 +66,8 @@ var waitQueueing = 5 * time.Second
 // storage is used to save our data locally.
 type storage struct {
 	sync.Mutex
+	// Dummy is there to satisfy new protobuf library.
+	Dummy int
 }
 
 type updateCollection struct {

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -163,6 +163,7 @@ func (s *Service) GetProof(req *GetProof) (resp *GetProofResponse, err error) {
 func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, ts []Transaction) (*skipchain.SkipBlock, error) {
 	var sb *skipchain.SkipBlock
 	var c collection.Collection
+	var mr []byte
 
 	if scID.IsNull() {
 		// For a genesis block, we create a throwaway collection.
@@ -172,11 +173,14 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, ts 
 		sb.Roster = r
 		sb.MaximumHeight = 10
 		sb.BaseHeight = 10
+		for _, t := range ts {
+			err := c.Add(t.Key, t.Value, t.Kind)
+			if err != nil {
+				return nil, errors.New("error while storing in collection: " + err.Error())
+			}
+		}
+		mr = c.GetRoot()
 	} else {
-		// For further blocks, we create a clone of the collection - this is
-		// TODO: not very memory-friendly - we need to use some kind of transactions.
-		c = s.getCollection(scID).coll.Clone()
-
 		sbLatest, err := s.db().GetLatest(s.db().GetByID(scID))
 		if err != nil {
 			return nil, errors.New(
@@ -186,15 +190,12 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, ts 
 		if r != nil {
 			sb.Roster = r
 		}
-	}
-
-	for _, t := range ts {
-		err := c.Add(t.Key, t.Value, t.Kind)
+		mr, err = s.getCollection(scID).tryHash(ts)
 		if err != nil {
-			return nil, errors.New("error while storing in collection: " + err.Error())
+			return nil, errors.New("error while getting merkle root from collection: " + err.Error())
 		}
 	}
-	mr := c.GetRoot()
+
 	data := &Data{
 		MerkleRoot:   mr,
 		Transactions: ts,

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -3,8 +3,10 @@ package service
 import (
 	"errors"
 	"fmt"
+	"log"
 
 	bolt "github.com/coreos/bbolt"
+	"github.com/dedis/onet"
 	"github.com/dedis/student_18_omniledger/omniledger/collection"
 	"github.com/dedis/student_18_omniledger/omniledger/darc"
 	"gopkg.in/dedis/onet.v2/network"
@@ -56,17 +58,18 @@ func (c *collectionDB) loadAll() {
 	})
 }
 
-func (c *collectionDB) Store(key, value, sig []byte) error {
-	c.coll.Add(key, value, sig)
+func (c *collectionDB) Store(t *Transaction) error {
+	log.Printf("Storing key/value: %x/%x in %p", t.Key, t.Value, c)
+	c.coll.Add(t.Key, t.Value, t.Kind)
 	err := c.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(c.bucketName))
-		if err := bucket.Put(key, value); err != nil {
+		if err := bucket.Put(t.Key, t.Value); err != nil {
 			return err
 		}
-		keysig := make([]byte, len(key)+3)
-		copy(keysig, key)
-		keysig = append(keysig, []byte("sig")...)
-		if err := bucket.Put(keysig, sig); err != nil {
+		keykind := make([]byte, len(t.Key)+4)
+		copy(keykind, t.Key)
+		keykind = append(keykind, []byte("kind")...)
+		if err := bucket.Put(keykind, t.Kind); err != nil {
 			return err
 		}
 		return nil
@@ -74,16 +77,8 @@ func (c *collectionDB) Store(key, value, sig []byte) error {
 	return err
 }
 
-func (c *collectionDB) GetValue(key []byte) (value, sig []byte, err error) {
-	// err = c.db.Update(func(tx *bolt.Tx) error {
-	// 	bucket := tx.Bucket([]byte(c.bucketName))
-	// 	value = bucket.Get(key)
-	// 	sig = bucket.Get(append(key, []byte("sig")...))
-	// 	return nil
-	// })
-	// return
-
-	// TODO: make it so that the collection only stores the hashes, not the values
+func (c *collectionDB) GetValueKind(key []byte) (value, kind []byte, err error) {
+	log.Printf("Getting key %x from %p", key, c)
 	proof, err := c.coll.Get(key).Record()
 	if err != nil {
 		return
@@ -101,7 +96,7 @@ func (c *collectionDB) GetValue(key []byte) (value, sig []byte, err error) {
 		err = errors.New("the value is not of type []byte")
 		return
 	}
-	sig, ok = hashes[1].([]byte)
+	kind, ok = hashes[1].([]byte)
 	if !ok {
 		err = errors.New("the signature is not of type []byte")
 		return
@@ -125,10 +120,17 @@ type Transaction struct {
 	Key   []byte
 	Kind  []byte
 	Value []byte
-	// type Signature struct {
-	//     Signature []byte
-	//     Signer SubjectPK
-	// }
 	// The signature is performed on the concatenation of the []bytes
 	Signature darc.Signature
+}
+
+// Data is the data passed to the Skipchain
+type Data struct {
+	// Root of the merkle tree after applying the transactions to the
+	// kv store
+	MerkleRoot []byte
+	// The transactions applied to the kv store with this block
+	Transactions []*Transaction
+	Timestamp    int64
+	Roster       *onet.Roster
 }

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -3,7 +3,6 @@ package service
 import (
 	"errors"
 	"fmt"
-	"log"
 
 	bolt "github.com/coreos/bbolt"
 	"github.com/dedis/onet"
@@ -59,7 +58,6 @@ func (c *collectionDB) loadAll() {
 }
 
 func (c *collectionDB) Store(t *Transaction) error {
-	log.Printf("Storing key/value: %x/%x in %p", t.Key, t.Value, c)
 	c.coll.Add(t.Key, t.Value, t.Kind)
 	err := c.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(c.bucketName))
@@ -78,7 +76,6 @@ func (c *collectionDB) Store(t *Transaction) error {
 }
 
 func (c *collectionDB) GetValueKind(key []byte) (value, kind []byte, err error) {
-	log.Printf("Getting key %x from %p", key, c)
 	proof, err := c.coll.Get(key).Record()
 	if err != nil {
 		return

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -65,16 +65,15 @@ func (c *collectionDB) tryHash(ts []Transaction) (mr []byte, rerr error) {
 		if err != nil {
 			rerr = err
 			return
-		} else {
-			// remove the pair after we got the merkle root.
-			defer func(k []byte) {
-				err = c.coll.Remove(k)
-				if err != nil {
-					rerr = err
-					mr = nil
-				}
-			}(t.Key)
 		}
+		// remove the pair after we got the merkle root.
+		defer func(k []byte) {
+			err = c.coll.Remove(k)
+			if err != nil {
+				rerr = err
+				mr = nil
+			}
+		}(t.Key)
 	}
 	mr = c.coll.GetRoot()
 	return

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -57,21 +57,24 @@ func (c *collectionDB) loadAll() {
 	})
 }
 
-// tryHash returns the merkle root of the collection as if the key value pair
-// had been added, without actually adding it.
+// tryHash returns the merkle root of the collection as if the key value pairs
+// in the transactions had been added, without actually adding it.
 func (c *collectionDB) tryHash(ts []Transaction) (mr []byte, rerr error) {
 	for _, t := range ts {
 		err := c.coll.Add(t.Key, t.Value, t.Kind)
 		if err != nil {
 			rerr = err
 			return
+		} else {
+			// remove the pair after we got the merkle root.
+			defer func(k []byte) {
+				err = c.coll.Remove(k)
+				if err != nil {
+					rerr = err
+					mr = nil
+				}
+			}(t.Key)
 		}
-		defer func() {
-			if err = c.coll.Remove(t.Key); err != nil {
-				rerr = err
-				mr = nil
-			}
-		}()
 	}
 	mr = c.coll.GetRoot()
 	return

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -127,7 +127,7 @@ type Data struct {
 	// kv store
 	MerkleRoot []byte
 	// The transactions applied to the kv store with this block
-	Transactions []*Transaction
+	Transactions []Transaction
 	Timestamp    int64
 	Roster       *onet.Roster
 }

--- a/omniledger/service/struct_test.go
+++ b/omniledger/service/struct_test.go
@@ -42,6 +42,41 @@ func TestCollectionDBStrange(t *testing.T) {
 	require.Equal(t, kind, k)
 }
 
+// TODO: Test good case, bad add case, bad remove case
+func TestCollectionDBtryHash(t *testing.T) {
+	tmpDB, err := ioutil.TempFile("", "tmpDB")
+	require.Nil(t, err)
+	tmpDB.Close()
+	defer os.Remove(tmpDB.Name())
+
+	db, err := bolt.Open(tmpDB.Name(), 0600, nil)
+	require.Nil(t, err)
+
+	cdb := newCollectionDB(db, testName)
+	ts := []Transaction{
+		Transaction{
+			Key:   []byte("key1"),
+			Kind:  []byte("kind1"),
+			Value: []byte("value1"),
+		},
+		Transaction{
+			Key:   []byte("key2"),
+			Kind:  []byte("kind2"),
+			Value: []byte("value2"),
+		},
+	}
+	mrTrial, err := cdb.tryHash(ts)
+	require.Nil(t, err)
+	_, _, err = cdb.GetValueKind([]byte("key1"))
+	require.EqualError(t, err, "no match found")
+	_, _, err = cdb.GetValueKind([]byte("key2"))
+	require.EqualError(t, err, "no match found")
+	cdb.Store(&ts[0])
+	cdb.Store(&ts[1])
+	mrReal := cdb.RootHash()
+	require.Equal(t, mrTrial, mrReal)
+}
+
 func TestCollectionDB(t *testing.T) {
 	kvPairs := 16
 

--- a/omniledger/service/struct_test.go
+++ b/omniledger/service/struct_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	bolt "github.com/coreos/bbolt"
 	"github.com/stretchr/testify/require"
@@ -126,6 +127,7 @@ func TestService_Store(t *testing.T) {
 		})
 		require.Nil(t, err)
 	}
+	time.Sleep(4 * waitQueueing)
 
 	// Retrieve the keypairs
 	for key, value := range pairs {


### PR DESCRIPTION
**THIS PR SUPERCEDES #29**
The changes implement a function `(c *collectionDB) tryHash(ts []Transaction) ([]byte, error)` which takes a slice of transactions, applies them to the collection, retrieves the merkle root and then rolls back the applied transactions.
This allows us to obtain a merkle root which can be proposed to the skipchain service, without having to copy the collection in order to not apply the changes to the collection before the corresponding block is accepted.

Superseded by #37