### PR TITLE
Multiple evolution signer

### DIFF
--- a/omniledger/darc/darc.go
+++ b/omniledger/darc/darc.go
@@ -380,19 +380,13 @@ func (d Darc) String() string {
 	for k, v := range d.Rules {
 		s += fmt.Sprintf("\n\t%s - \"%s\"", k, v)
 	}
-	s += fmt.Sprintf("\nSignature count: %d", len(d.Signatures))
-	/*
-		signer, err := d.GetSignerDarc()
-		var signerStr string
-		if err != nil {
-			signerStr = "<" + err.Error() + ">"
-		} else if signer == nil {
-			signerStr = "<nil>"
+	for i, sig := range d.Signatures {
+		if sig == nil {
+			s += fmt.Sprintf("\n\t%d - <nil signature>", i)
 		} else {
-			signerStr = fmt.Sprintf("%x", signer.GetID())
+			s += fmt.Sprintf("\n\t%d - id: %s, sig: %x", i, sig.Signer.String(), sig.Signature)
 		}
-		s += fmt.Sprintf("\nSignerDarc: %s", signerStr)
-	*/
+	}
 	return s
 }
 

--- a/omniledger/darc/darc.go
+++ b/omniledger/darc/darc.go
@@ -55,7 +55,8 @@ const evolve = "_evolve"
 const sign = "_sign"
 
 // InitRules initialise a set of rules with the default actions "_evolve" and
-// "_sign".
+// "_sign". Signers are joined with logical-Or, owners are also joined with
+// logical-OR. If other expressions are needed, please set the rules manually.
 func InitRules(owners []*Identity, signers []*Identity) Rules {
 	rs := make(Rules)
 

--- a/omniledger/darc/darc_example_test.go
+++ b/omniledger/darc/darc_example_test.go
@@ -10,14 +10,14 @@ import (
 func Example() {
 	// We can create a new darc like so.
 	owner1 := darc.NewSignerEd25519(nil, nil)
-	rules1 := darc.InitEvolutionRule(owner1.Identity())
+	rules1 := darc.InitRules([]*darc.Identity{owner1.Identity()}, []*darc.Identity{})
 	d1 := darc.NewDarc(rules1, []byte("example darc"))
 	fmt.Println(d1.Verify())
 
 	// Create another one and set the first to evolve to the second. The
 	// second darc will have a different evolution rule.
 	owner2 := darc.NewSignerEd25519(nil, nil)
-	rules2 := darc.InitEvolutionRule(owner2.Identity())
+	rules2 := darc.InitRules([]*darc.Identity{owner2.Identity()}, []*darc.Identity{})
 	d2 := darc.NewDarc(rules2, []byte("example darc 2"))
 	fmt.Println(d2.Verify())
 	d2.Evolve([]*darc.Darc{d1}, owner1)

--- a/omniledger/darc/darc_test.go
+++ b/omniledger/darc/darc_test.go
@@ -105,6 +105,19 @@ func TestDarc_EvolveOne(t *testing.T) {
 	require.Nil(t, dNew.Verify())
 	require.Nil(t, dNew.Evolve(darcs, owner1))
 	require.Nil(t, dNew.Verify())
+	// use logical-and in the evolve expression
+	// verification should if only one owner signs the darc
+	require.Nil(t, dNew.Rules.UpdateEvolution(expression.InitAndExpr(owner2.Identity().String(), owner1.Identity().String())))
+	require.Nil(t, dNew.Evolve(darcs, owner2))
+	require.Nil(t, dNew.Verify())
+	darcs = append(darcs, dNew)
+	dNew2 := dNew.Copy()
+	require.Nil(t, dNew2.Evolve(darcs, owner2))
+	require.NotNil(t, dNew2.Verify())
+	require.Nil(t, dNew2.Evolve(darcs, owner1))
+	require.NotNil(t, dNew2.Verify())
+	require.Nil(t, dNew2.Evolve(darcs, owner2, owner1))
+	require.Nil(t, dNew2.Verify())
 }
 
 // TestDarc_EvolveMore is similar to TestDarc_EvolveOne but testing for

--- a/omniledger/darc/darc_test.go
+++ b/omniledger/darc/darc_test.go
@@ -10,14 +10,14 @@ import (
 func TestRules(t *testing.T) {
 	// one owner
 	owner := createIdentity()
-	rules := InitEvolutionRule(owner)
+	rules := InitRules([]*Identity{owner}, []*Identity{})
 	expr, ok := rules[evolve]
 	require.True(t, ok)
 	require.Equal(t, string(expr), owner.String())
 
 	// two owners
 	owners := []*Identity{owner, createIdentity()}
-	rules = InitEvolutionRule(owners...)
+	rules = InitRules(owners, []*Identity{})
 	expr, ok = rules[evolve]
 	require.True(t, ok)
 	require.Equal(t, string(expr), owners[0].String()+" | "+owners[1].String())
@@ -27,7 +27,7 @@ func TestNewDarc(t *testing.T) {
 	desc := []byte("mydarc")
 	owner := createIdentity()
 
-	d := NewDarc(InitEvolutionRule(owner), desc)
+	d := NewDarc(InitRules([]*Identity{owner}, []*Identity{}), desc)
 	require.Equal(t, desc, d.Description)
 	require.Equal(t, string(d.Rules.GetEvolutionExpr()), owner.String())
 }
@@ -183,17 +183,17 @@ func TestDarc_EvolveMoreOnline(t *testing.T) {
 
 	// create darcs that do not have the full path
 	lightDarc1 := darcs[len(darcs)-1].Copy()
-	lightDarc1.Signature = &Signature{
-		Signature:  copyBytes(darcs[len(darcs)-1].Signature.Signature),
-		Signer:     darcs[len(darcs)-1].Signature.Signer,
-		PathDigest: darcs[len(darcs)-1].Signature.PathDigest,
-	}
+	lightDarc1.Signatures = []*Signature{&Signature{
+		Signature:  copyBytes(darcs[len(darcs)-1].Signatures[0].Signature),
+		Signer:     darcs[len(darcs)-1].Signatures[0].Signer,
+		PathDigest: darcs[len(darcs)-1].Signatures[0].PathDigest,
+	}}
 	lightDarc2 := darcs[len(darcs)-2].Copy()
-	lightDarc2.Signature = &Signature{
-		Signature:  copyBytes(darcs[len(darcs)-2].Signature.Signature),
-		Signer:     darcs[len(darcs)-2].Signature.Signer,
-		PathDigest: darcs[len(darcs)-2].Signature.PathDigest,
-	}
+	lightDarc2.Signatures = []*Signature{&Signature{
+		Signature:  copyBytes(darcs[len(darcs)-2].Signatures[0].Signature),
+		Signer:     darcs[len(darcs)-2].Signatures[0].Signer,
+		PathDigest: darcs[len(darcs)-2].Signatures[0].PathDigest,
+	}}
 
 	// verification should fail if the callback is not set
 	require.NotNil(t, lightDarc1.Verify())
@@ -321,7 +321,7 @@ func createDarc(nbrOwners int, desc string) *testDarc {
 		td.owners = append(td.owners, s)
 		td.ids = append(td.ids, id)
 	}
-	rules := InitEvolutionRule(td.ids...)
+	rules := InitRules(td.ids, []*Identity{})
 	td.darc = NewDarc(rules, []byte(desc))
 	return td
 }

--- a/omniledger/darc/struct.go
+++ b/omniledger/darc/struct.go
@@ -50,6 +50,11 @@ type Darc struct {
 	BaseID ID
 	// Rules map an action to an expression.
 	Rules Rules
+	// Represents the path to get up to information to be able to verify
+	// this signature.  These justify the right of the signer to push a new
+	// Darc.  These are ordered from the oldest to the newest, i.e.
+	// Darcs[0] should be the base Darc.
+	Path []*Darc
 	// Signature is calculated over the protobuf representation of [Rules, Version, Description]
 	// and needs to be created by an Owner from the previous valid Darc.
 	Signatures []*Signature
@@ -96,11 +101,6 @@ type Signature struct {
 	Signature []byte
 	// Signer is the Idenity (public key or another Darc) of the signer
 	Signer Identity
-	// Represents the path to get up to information to be able to verify
-	// this signature.  These justify the right of the signer to push a new
-	// Darc.  These are ordered from the oldest to the newest, i.e.
-	// Darcs[0] should be the base Darc.
-	Path []*Darc
 	// PathDigest should be set when Path has length 0. It should be the
 	// same as the return value of GetPathMsg.
 	PathDigest []byte

--- a/omniledger/darc/struct.go
+++ b/omniledger/darc/struct.go
@@ -52,7 +52,7 @@ type Darc struct {
 	Rules Rules
 	// Signature is calculated over the protobuf representation of [Rules, Version, Description]
 	// and needs to be created by an Owner from the previous valid Darc.
-	Signature *Signature
+	Signatures []*Signature
 }
 
 // Action is TODO


### PR DESCRIPTION
This commit introduces the ability to have multiple signers sign off an
evolution. This is necessary when the identifiers in the "evolve"
expressions are joined with logical-and.

Path is moved from Signature to the Darc because all signatures
should be on the same path. 