### PR TITLE
Add verifiers

### DIFF
--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -405,3 +405,10 @@ func newService(c *onet.Context) (onet.Service, error) {
 	}
 	return s, nil
 }
+
+// We use the omniledger as a receiver (as is done in the identity service),
+// so we can access e.g. the collectionDBs of the service.
+func (s *service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool {
+	// Dummy implementation, always returns true for the moment.
+	return true
+}

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -24,7 +24,7 @@ import (
 
 // Used for tests
 var omniledgerID onet.ServiceID
-var VerifyOmni = skipchain.VerifierID(uuid.NewV5(uuid.NamespaceURL, "Omni"))
+var verifyOmniledger = skipchain.VerifierID(uuid.NewV5(uuid.NamespaceURL, "Omniledger"))
 
 const keyMerkleRoot = "merkleroot"
 const keyNewKey = "newkey"
@@ -171,6 +171,7 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, ts 
 		sb.Roster = r
 		sb.MaximumHeight = 10
 		sb.BaseHeight = 10
+		sb.VerifierIDs = []skipchain.VerifierID{skipchain.VerifyBase, verifyOmniledger}
 		for _, t := range ts {
 			log.Printf("Adding transaction %+v", t)
 			err := c.Add(t.Key, t.Value, t.Kind)
@@ -406,13 +407,14 @@ func newService(c *onet.Context) (onet.Service, error) {
 		return nil, err
 	}
 
-	skipchain.RegisterVerification(c, VerifyOmni, s.verifySkipBlock)
+	skipchain.RegisterVerification(c, verifyOmniledger, s.verifySkipBlock)
 	return s, nil
 }
 
 // We use the omniledger as a receiver (as is done in the identity service),
 // so we can access e.g. the collectionDBs of the service.
 func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool {
+	log.Lvlf4("calling verifySkipBlock")
 	// Dummy implementation, always returns true for the moment.
 	return true
 }

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -171,6 +171,7 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, ts 
 		sb.Roster = r
 		sb.MaximumHeight = 10
 		sb.BaseHeight = 10
+		// We have to register the verification functions in the genesis block
 		sb.VerifierIDs = []skipchain.VerifierID{skipchain.VerifyBase, verifyOmniledger}
 		for _, t := range ts {
 			log.Printf("Adding transaction %+v", t)
@@ -414,7 +415,6 @@ func newService(c *onet.Context) (onet.Service, error) {
 // We use the omniledger as a receiver (as is done in the identity service),
 // so we can access e.g. the collectionDBs of the service.
 func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool {
-	log.Lvlf4("calling verifySkipBlock")
 	// Dummy implementation, always returns true for the moment.
 	return true
 }

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -17,12 +17,14 @@ import (
 	"gopkg.in/dedis/onet.v2"
 	"gopkg.in/dedis/onet.v2/log"
 	"gopkg.in/dedis/onet.v2/network"
+	"gopkg.in/satori/go.uuid.v1"
 
 	"github.com/dedis/student_18_omniledger/omniledger/collection"
 )
 
 // Used for tests
 var omniledgerID onet.ServiceID
+var VerifyOmni = skipchain.VerifierID(uuid.NewV5(uuid.NamespaceURL, "Omni"))
 
 const keyMerkleRoot = "merkleroot"
 const keyNewKey = "newkey"
@@ -403,12 +405,14 @@ func newService(c *onet.Context) (onet.Service, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	skipchain.RegisterVerification(c, VerifyOmni, s.verifySkipBlock)
 	return s, nil
 }
 
 // We use the omniledger as a receiver (as is done in the identity service),
 // so we can access e.g. the collectionDBs of the service.
-func (s *service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool {
+func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool {
 	// Dummy implementation, always returns true for the moment.
 	return true
 }


### PR DESCRIPTION
Resolves #15 .
The changes add a dummy verification function which always returns true. It is registered with the skipchain and set in each genesis block.

No testcases are added for the moment, but the changes have been tested by hand: Changing the verification functions return value to `false` makes the tests fail with the expected behavior, whereas returning `true` passes all tests.