### PR TITLE
Ethereums way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,5 @@ test_playground:
 proto:
 	awk -f proto.awk struct.go > external/proto/sicpa.proto
 	cd external; make
+
+test_simple: test_fmt test_lint test_goveralls

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -418,3 +418,18 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 	// Dummy implementation, always returns true for the moment.
 	return true
 }
+
+// Since the outcome of the verification depends on the state of the collection
+// whihc is to be modified, we use it as a receiver here.
+func (cdb *collectionDB) verifyDummyKind(tx *Transaction) bool {
+	switch a := tx.Action; a {
+	case Create:
+		return true
+	case Update:
+		return true
+	case Remove:
+		return false
+	default:
+		return false
+	}
+}

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -415,6 +415,23 @@ func newService(c *onet.Context) (onet.Service, error) {
 // We use the omniledger as a receiver (as is done in the identity service),
 // so we can access e.g. the collectionDBs of the service.
 func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool {
+	_, dataI, err := network.Unmarshal(newSB.Data, cothority.Suite)
+	data, ok := dataI.(*Data)
+	if err != nil || !ok {
+		log.Errorf("couldn't unmarshal data")
+		return false
+	}
+	txs := data.Transactions
+	cdb := s.getCollection(newSB.Hash)
+	for _, tx := range txs {
+		switch kind := string(tx.Kind); kind {
+		case "dummy":
+			return cdb.verifyDummyKind(&tx)
+		default:
+			return true
+		}
+
+	}
 	// Dummy implementation, always returns true for the moment.
 	return true
 }

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -335,11 +335,6 @@ func (s *Service) createQueueWorker(scID skipchain.SkipBlockID) (chan Transactio
 						to = time.After(waitQueueing)
 						continue
 					}
-					// For testing purposes, I remove all the transactions from
-					// the queue if the block was not accepted by the skipchain.
-					// A better solution would be to mark them invalid and have
-					// the skipchain ignore them during the verification.
-					// TODO: Above.
 					ts = []Transaction{}
 				}
 				to = time.After(waitQueueing)

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -152,11 +152,13 @@ func TestService_GetProof(t *testing.T) {
 	key, values, err = rep.Proof.KeyValue()
 	require.NotNil(t, err)
 }
-func TestService_FailDummyVerification(t *testing.T) {
+
+func TestService_DummyVerification(t *testing.T) {
 	s := newSer(t, 1)
 	defer s.local.CloseAll()
 	defer closeQueues(s.local)
 
+	RegisterVerification(s.hosts[0], "dummy", verifyDummyKind)
 	akvresp, err := s.service.SetKeyValue(&SetKeyValue{
 		Version: 0,
 	})
@@ -188,34 +190,6 @@ func TestService_FailDummyVerification(t *testing.T) {
 	match := pr.Proof.InclusionProof.Match()
 	require.False(t, match)
 
-}
-
-func TestService_SucceedDummyVerification(t *testing.T) {
-	s := newSer(t, 1)
-	defer s.local.CloseAll()
-	defer closeQueues(s.local)
-
-	akvresp, err := s.service.SetKeyValue(&SetKeyValue{
-		Version: 0,
-	})
-	require.NotNil(t, err)
-
-	key1 := []byte("a")
-	value1 := []byte("a")
-	akvresp, err = s.service.SetKeyValue(&SetKeyValue{
-		Version:     CurrentVersion,
-		SkipchainID: s.sb.SkipChainID(),
-		Transaction: Transaction{
-			Key:    key1,
-			Kind:   []byte("dammy"),
-			Value:  value1,
-			Action: Update,
-		},
-	})
-	require.Nil(t, err)
-	require.NotNil(t, akvresp)
-	require.Equal(t, CurrentVersion, akvresp.Version)
-
 	key2 := []byte("b")
 	value2 := []byte("b")
 	akvresp, err = s.service.SetKeyValue(&SetKeyValue{
@@ -232,17 +206,7 @@ func TestService_SucceedDummyVerification(t *testing.T) {
 	require.NotNil(t, akvresp)
 	require.Equal(t, CurrentVersion, akvresp.Version)
 
-	time.Sleep(2 * waitQueueing)
-	pr, err := s.service.GetProof(&GetProof{
-		Version: CurrentVersion,
-		ID:      s.sb.SkipChainID(),
-		Key:     key1,
-	})
-	require.Nil(t, err)
-	match := pr.Proof.InclusionProof.Match()
-	require.True(t, match)
-
-	time.Sleep(2 * waitQueueing)
+	time.Sleep(4 * waitQueueing)
 	pr, err = s.service.GetProof(&GetProof{
 		Version: CurrentVersion,
 		ID:      s.sb.SkipChainID(),
@@ -251,6 +215,22 @@ func TestService_SucceedDummyVerification(t *testing.T) {
 	require.Nil(t, err)
 	match = pr.Proof.InclusionProof.Match()
 	require.True(t, match)
+
+	time.Sleep(4 * waitQueueing)
+}
+
+func verifyDummyKind(cdb *collectionDB, tx *Transaction) bool {
+	switch a := tx.Action; a {
+	case Create:
+		return true
+	case Update:
+		return true
+	// removing and unknown actions are forbidden
+	case Remove:
+		return false
+	default:
+		return false
+	}
 }
 
 type ser struct {

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -128,6 +128,18 @@ func (c *collectionDB) tryHash(ts []Transaction) (mr []byte, rerr error) {
 	return
 }
 
+// Action describes how the collectionDB will be modified.
+type Action int
+
+const (
+	// Create allows to insert a new key-value association.
+	Create Action = iota
+	// Update allows to change the value of an existing key.
+	Update
+	// Remove allows to delete an existing key-value association.
+	Remove
+)
+
 // Transaction is the struct specifying the modifications to the skipchain.
 // Key is the key chosen by the user, Kind is the kind of value to store
 // (e.g. a drac...). The key used in the conode's collection will be
@@ -136,9 +148,10 @@ func (c *collectionDB) tryHash(ts []Transaction) (mr []byte, rerr error) {
 // For a Transaction to be valid, there must exist a path from the master-darc
 // in the genesis block to the SubjectPK in Signature.
 type Transaction struct {
-	Key   []byte
-	Kind  []byte
-	Value []byte
+	Action Action
+	Key    []byte
+	Kind   []byte
+	Value  []byte
 	// The signature is performed on the concatenation of the []bytes
 	Signature darc.Signature
 }

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -22,6 +22,8 @@ type collectionDB struct {
 	coll       collection.Collection
 }
 
+type OmniledgerVerifier func(cdb *collectionDB, tx *Transaction) bool
+
 // newCollectionDB initialises a structure and reads all key/value pairs to store
 // it in the collection.
 func newCollectionDB(db *bolt.DB, name []byte) *collectionDB {

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -22,6 +22,10 @@ type collectionDB struct {
 	coll       collection.Collection
 }
 
+// OmniledgerVerifier is the type signature of the verification functions
+// which can be registered with the omniledger service.
+// Since the outcome of the verification depends on the state of the collection
+// which is to be modified, we pass it as a pointer here.
 type OmniledgerVerifier func(cdb *collectionDB, tx *Transaction) bool
 
 // newCollectionDB initialises a structure and reads all key/value pairs to store

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -133,7 +133,7 @@ type Action int
 
 const (
 	// Create allows to insert a new key-value association.
-	Create Action = iota
+	Create Action = iota + 1
 	// Update allows to change the value of an existing key.
 	Update
 	// Remove allows to delete an existing key-value association.


### PR DESCRIPTION
This PR is related to #17 .

The changes add `RegisterVerification` to the omniledger service. It allows to register a function of type `OmniledgerVerifier` with the service which will be applied to all transactions of the specified kind.