### PR TITLE
Move path digest to darc

### DIFF
--- a/omniledger/darc/darc_test.go
+++ b/omniledger/darc/darc_test.go
@@ -197,15 +197,13 @@ func TestDarc_EvolveMoreOnline(t *testing.T) {
 	// create darcs that do not have the full path
 	lightDarc1 := darcs[len(darcs)-1].Copy()
 	lightDarc1.Signatures = []*Signature{&Signature{
-		Signature:  copyBytes(darcs[len(darcs)-1].Signatures[0].Signature),
-		Signer:     darcs[len(darcs)-1].Signatures[0].Signer,
-		PathDigest: darcs[len(darcs)-1].Signatures[0].PathDigest,
+		Signature: copyBytes(darcs[len(darcs)-1].Signatures[0].Signature),
+		Signer:    darcs[len(darcs)-1].Signatures[0].Signer,
 	}}
 	lightDarc2 := darcs[len(darcs)-2].Copy()
 	lightDarc2.Signatures = []*Signature{&Signature{
-		Signature:  copyBytes(darcs[len(darcs)-2].Signatures[0].Signature),
-		Signer:     darcs[len(darcs)-2].Signatures[0].Signer,
-		PathDigest: darcs[len(darcs)-2].Signatures[0].PathDigest,
+		Signature: copyBytes(darcs[len(darcs)-2].Signatures[0].Signature),
+		Signer:    darcs[len(darcs)-2].Signatures[0].Signer,
 	}}
 
 	// verification should fail if the callback is not set

--- a/omniledger/darc/struct.go
+++ b/omniledger/darc/struct.go
@@ -55,6 +55,9 @@ type Darc struct {
 	// Darc.  These are ordered from the oldest to the newest, i.e.
 	// Darcs[0] should be the base Darc.
 	Path []*Darc
+	// PathDigest should be set when Path has length 0. It should be the
+	// same as the return value of GetPathMsg.
+	PathDigest []byte
 	// Signature is calculated over the protobuf representation of [Rules, Version, Description]
 	// and needs to be created by an Owner from the previous valid Darc.
 	Signatures []*Signature
@@ -104,9 +107,6 @@ type Signature struct {
 	Signature []byte
 	// Signer is the Idenity (public key or another Darc) of the signer
 	Signer Identity
-	// PathDigest should be set when Path has length 0. It should be the
-	// same as the return value of GetPathMsg.
-	PathDigest []byte
 }
 
 // Signer is a generic structure that can hold different types of signers


### PR DESCRIPTION
Move PathDigest from Signature to Darc because  the PathDigest is the same for all signatures in a darc. This is also a prerequisite for the upcoming work on generalising requests.

Please merge #48 into this PR, and then merge this PR into master.