### PR TITLE
Generalise Request to support evolution

### DIFF
--- a/omniledger/darc/darc_example_test.go
+++ b/omniledger/darc/darc_example_test.go
@@ -1,6 +1,7 @@
 package darc_test
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/dedis/student_18_omniledger/omniledger/darc"
@@ -8,36 +9,53 @@ import (
 )
 
 func Example() {
+	// Consider a client-server configuration. Where the client holds the
+	// credentials and wants the server to check for requests or evolve
+	// darcs. We begin by creating a darc on the server.
 	// We can create a new darc like so.
 	owner1 := darc.NewSignerEd25519(nil, nil)
 	rules1 := darc.InitRules([]*darc.Identity{owner1.Identity()}, []*darc.Identity{})
 	d1 := darc.NewDarc(rules1, []byte("example darc"))
 	fmt.Println(d1.Verify())
 
-	// Create another one and set the first to evolve to the second. The
-	// second darc will have a different evolution rule.
+	// Now the client wants to evolve the darc (change the owner), so it
+	// creates a request and then sends it to the server.
 	owner2 := darc.NewSignerEd25519(nil, nil)
 	rules2 := darc.InitRules([]*darc.Identity{owner2.Identity()}, []*darc.Identity{})
 	d2 := darc.NewDarc(rules2, []byte("example darc 2"))
-	fmt.Println(d2.Verify())
-	d2.Evolve([]*darc.Darc{d1}, owner1)
-	fmt.Println(d2.Verify())
+	d2.EvolveFrom([]*darc.Darc{d1})
+	r, err := d2.MakeEvolveRequest(owner1)
+	fmt.Println(err)
+
+	// Client sends request r to the server, and the server must verify it.
+	// Usually the server will look in its database for the base ID of the
+	// darc in the request and find the latest one. But in this case we
+	// assume it already knows. If the check is successful, then the
+	// server should add the darc in the request to its database.
+	fmt.Println(d1.CheckRequest(r))
+	d2Server, _ := r.MsgToDarc([]*darc.Darc{d1}) // Server stores d2Server.
+	fmt.Println(bytes.Equal(d2Server.GetID(), d2.GetID()))
+
+	// If the darcs stored on the server are trustworthy, then using
+	// `CheckRequest` is enough. To do a complete verification, Darc.Verify
+	// should be used. This will traverse the chain of evolution and verify
+	// every evolution. However, the Darc.Path attribute must be set.
+	fmt.Println(d2Server.Verify())
 
 	// The above illustrates the basic use of darcs, in the following
 	// examples, we show how to create custom rules to enforce custom
-	// policies.
+	// policies. We begin by making another evolution that has a custom
+	// action.
 	owner3 := darc.NewSignerEd25519(nil, nil)
 	action3 := darc.Action("custom_action")
 	expr3 := expression.InitAndExpr(
 		owner1.Identity().String(),
 		owner2.Identity().String(),
 		owner3.Identity().String())
-	d3 := d2.Copy()
+	d3 := d1.Copy()
 	d3.Rules.AddRule(action3, expr3)
-	d3.Evolve([]*darc.Darc{d1, d2}, owner2)
-	fmt.Println(d3.Verify())
 
-	r, _ := darc.NewRequest(d3.GetID(), action3, []byte("example request"), owner3)
+	r, _ = darc.NewRequest(d3.GetID(), action3, []byte("example request"), owner3)
 	if err := d3.CheckRequest(r); err != nil {
 		// not ok because the expression is created using logical and
 		fmt.Println("not ok!")
@@ -52,6 +70,7 @@ func Example() {
 	// <nil>
 	// <nil>
 	// <nil>
+	// true
 	// <nil>
 	// not ok!
 	// ok!

--- a/omniledger/darc/darc_test.go
+++ b/omniledger/darc/darc_test.go
@@ -97,26 +97,26 @@ func TestDarc_EvolveOne(t *testing.T) {
 	// the identity of the signer cannot be id3, it does not have the
 	// evolve permission
 	owner3 := NewSignerEd25519(nil, nil)
-	require.Nil(t, dNew.Evolve(darcs, owner3))
+	require.Nil(t, localEvolution(dNew, darcs, owner3))
 	require.NotNil(t, dNew.Verify())
 	// it should be possible to sign with owner2 and owner1 because they
 	// are in the first darc and have the evolve permission
-	require.Nil(t, dNew.Evolve(darcs, owner2))
+	require.Nil(t, localEvolution(dNew, darcs, owner2))
 	require.Nil(t, dNew.Verify())
-	require.Nil(t, dNew.Evolve(darcs, owner1))
+	require.Nil(t, localEvolution(dNew, darcs, owner1))
 	require.Nil(t, dNew.Verify())
 	// use logical-and in the evolve expression
 	// verification should if only one owner signs the darc
 	require.Nil(t, dNew.Rules.UpdateEvolution(expression.InitAndExpr(owner2.Identity().String(), owner1.Identity().String())))
-	require.Nil(t, dNew.Evolve(darcs, owner2))
+	require.Nil(t, localEvolution(dNew, darcs, owner2))
 	require.Nil(t, dNew.Verify())
 	darcs = append(darcs, dNew)
 	dNew2 := dNew.Copy()
-	require.Nil(t, dNew2.Evolve(darcs, owner2))
+	require.Nil(t, localEvolution(dNew2, darcs, owner2))
 	require.NotNil(t, dNew2.Verify())
-	require.Nil(t, dNew2.Evolve(darcs, owner1))
+	require.Nil(t, localEvolution(dNew2, darcs, owner1))
 	require.NotNil(t, dNew2.Verify())
-	require.Nil(t, dNew2.Evolve(darcs, owner2, owner1))
+	require.Nil(t, localEvolution(dNew2, darcs, owner2, owner1))
 	require.Nil(t, dNew2.Verify())
 }
 
@@ -135,7 +135,7 @@ func TestDarc_EvolveMore(t *testing.T) {
 		dNew.IncrementVersion()
 		newOwner := NewSignerEd25519(nil, nil)
 		require.Nil(t, dNew.Rules.UpdateEvolution([]byte(newOwner.Identity().String())))
-		require.Nil(t, dNew.Evolve(darcs, prevOwner))
+		require.Nil(t, localEvolution(dNew, darcs, prevOwner))
 		// require.Nil(t, dNew.Verify())
 		darcs = append(darcs, dNew)
 		prevOwner = newOwner
@@ -171,7 +171,7 @@ func TestDarc_EvolveMoreOnline(t *testing.T) {
 		dNew.IncrementVersion()
 		newOwner := NewSignerEd25519(nil, nil)
 		require.Nil(t, dNew.Rules.UpdateEvolution([]byte(newOwner.Identity().String())))
-		require.Nil(t, dNew.Evolve(darcs, prevOwner))
+		require.Nil(t, localEvolution(dNew, darcs, prevOwner))
 		require.Nil(t, dNew.Verify())
 		darcs = append(darcs, dNew)
 		prevOwner = newOwner
@@ -277,6 +277,41 @@ func TestDarc_Rules(t *testing.T) {
 	require.NotNil(t, d.CheckRequest(r))
 }
 
+func TestDarc_EvolveRequest(t *testing.T) {
+	td := createDarc(1, "testdarc")
+	require.Nil(t, td.darc.Verify())
+
+	dNew := td.darc.Copy()
+	require.Nil(t, dNew.EvolveFrom([]*Darc{td.darc}))
+	var err error
+	var r *Request
+
+	// cannot create request with nil darc
+	var nilDarc *Darc
+	r, err = nilDarc.MakeEvolveRequest()
+	require.NotNil(t, err)
+	require.Nil(t, r)
+
+	// cannot create request with no signers
+	r, err = dNew.MakeEvolveRequest()
+	require.NotNil(t, err)
+	require.Nil(t, r)
+
+	// create a request with a wrong signer, the creation should succeed
+	// but the verification shold fail
+	badOwner := NewSignerEd25519(nil, nil)
+	r, err = dNew.MakeEvolveRequest(badOwner)
+	require.Nil(t, err)
+	require.NotNil(t, r)
+	require.NotNil(t, td.darc.CheckRequest(r))
+
+	// create the request with the right signer and it should pass
+	r, err = dNew.MakeEvolveRequest(td.owners[0])
+	require.Nil(t, err)
+	require.NotNil(t, r)
+	require.Nil(t, td.darc.CheckRequest(r))
+}
+
 // TestDarc_Delegation in this test we test delegation. We start with two
 // darcs, each has one evolution, i.e. d1 -> d2, d3 -> d4. Then, d2 adds d3 as
 // one of the identities with the evolve permission. Then, d4 should have the
@@ -290,21 +325,21 @@ func TestDarc_Delegation(t *testing.T) {
 	require.Nil(t, td3.darc.Rules.UpdateSign(td3.darc.Rules.GetEvolutionExpr()))
 	require.Nil(t, td4.darc.Rules.UpdateSign(td4.darc.Rules.GetEvolutionExpr()))
 
-	require.Nil(t, td2.darc.Evolve([]*Darc{td1.darc}, td1.owners[0]))
+	require.Nil(t, localEvolution(td2.darc, []*Darc{td1.darc}, td1.owners[0]))
 	require.Nil(t, td2.darc.Verify())
 
-	require.Nil(t, td4.darc.Evolve([]*Darc{td3.darc}, td3.owners[0]))
+	require.Nil(t, localEvolution(td4.darc, []*Darc{td3.darc}, td3.owners[0]))
 	require.Nil(t, td4.darc.Verify())
 
 	id3 := NewIdentityDarc(td3.darc.GetID())
 	d2Expr := []byte(id3.String())
 	require.Nil(t, td2.darc.Rules.UpdateEvolution(d2Expr))
 	require.NotNil(t, td2.darc.Verify())
-	require.Nil(t, td2.darc.Evolve([]*Darc{td1.darc}, td1.owners[0]))
+	require.Nil(t, localEvolution(td2.darc, []*Darc{td1.darc}, td1.owners[0]))
 	require.Nil(t, td2.darc.Verify())
 
 	td5 := createDarc(2, "testdarc5")
-	require.Nil(t, td5.darc.Evolve([]*Darc{td1.darc, td2.darc}, td3.owners[0]))
+	require.Nil(t, localEvolution(td5.darc, []*Darc{td1.darc, td2.darc}, td3.owners[0]))
 	require.NotNil(t, td5.darc.Verify())
 	getDarc := func(id string) *Darc {
 		if id == td3.darc.GetIdentityString() {
@@ -319,7 +354,7 @@ func TestDarc_Delegation(t *testing.T) {
 	// td3.owners which is out of date.
 	require.NotNil(t, td5.darc.VerifyWithCB(getDarc))
 	// If the evolution is signed by the latest darc, then it's ok.
-	require.Nil(t, td5.darc.Evolve([]*Darc{td1.darc, td2.darc}, td4.owners[0]))
+	require.Nil(t, localEvolution(td5.darc, []*Darc{td1.darc, td2.darc}, td4.owners[0]))
 	require.Nil(t, td5.darc.VerifyWithCB(getDarc))
 }
 
@@ -358,16 +393,16 @@ func TestDarc_DelegationChain(t *testing.T) {
 	}
 	td := createDarc(1, "new")
 	// cannot do evolution because owner is not in the evolve rule
-	require.Nil(t, td.darc.Evolve([]*Darc{darcs[0]}, owners[0]))
+	require.Nil(t, localEvolution(td.darc, []*Darc{darcs[0]}, owners[0]))
 	require.NotNil(t, td.darc.VerifyWithCB(getDarc))
 	// fail because only the key in the latest darc can sign
 	for _, o := range owners[:n-1] {
-		require.Nil(t, td.darc.Evolve([]*Darc{darcs[0]}, o))
+		require.Nil(t, localEvolution(td.darc, []*Darc{darcs[0]}, o))
 		require.NotNil(t, td.darc.VerifyWithCB(getDarc))
 	}
 	// only the last one, containing the actual key that is in the signer
 	// expression, should evaluate to true.
-	require.Nil(t, td.darc.Evolve([]*Darc{darcs[0]}, owners[n-1]))
+	require.Nil(t, localEvolution(td.darc, []*Darc{darcs[0]}, owners[n-1]))
 	require.Nil(t, td.darc.VerifyWithCB(getDarc))
 }
 
@@ -406,4 +441,23 @@ func createIdentity() *Identity {
 func createSignerIdentity() (*Signer, *Identity) {
 	signer := NewSignerEd25519(nil, nil)
 	return signer, signer.Identity()
+}
+
+func localEvolution(newDarc *Darc, path []*Darc, signers ...*Signer) error {
+	if err := newDarc.EvolveFrom(path); err != nil {
+		return err
+	}
+	r, err := newDarc.MakeEvolveRequest(signers...)
+	if err != nil {
+		return err
+	}
+	sigs := make([]*Signature, len(signers))
+	for i := range r.Identities {
+		sigs[i] = &Signature{
+			Signature: r.Signatures[i],
+			Signer:    *r.Identities[i],
+		}
+	}
+	newDarc.Signatures = sigs
+	return nil
 }

--- a/omniledger/darc/struct.go
+++ b/omniledger/darc/struct.go
@@ -128,11 +128,16 @@ type SignerX509EC struct {
 	secret []byte
 }
 
+type innerRequest struct {
+	BaseID     ID
+	Action     Action
+	Msg        []byte
+	Identities []*Identity
+	// TODO add the darc for where the identities should come from, e.g. SignerDarcs []string
+}
+
 // Request is the structure that the client must provide to be verified
 type Request struct {
-	ID         ID          // for identifying the darc
-	Action     Action      // do we need this, also specific to the rule?
-	Msg        []byte      // what the request wants to do, application specific
-	Identities []*Identity //
-	Signatures [][]byte    // we need multi signatures because expression, for every identity
+	innerRequest
+	Signatures [][]byte
 }


### PR DESCRIPTION
We change the message that signers must sign to evolve a darc to be a
digest of a Request struct, where before it was a digest of the darc.
This approach generalises our Request struct to works for every kind of
request. It also simplifies verification because we can re-use many of
the existing functions from Darc.Verify.

Please merge this PR into #47 and then merge #47 into master.