### PR TITLE
Initial architecture for adding genesis block/darc

### DIFF
--- a/omniledger/darc/darc.go
+++ b/omniledger/darc/darc.go
@@ -55,8 +55,8 @@ const evolve = "_evolve"
 const sign = "_sign"
 
 // InitRules initialise a set of rules with the default actions "_evolve" and
-// "_sign". Signers are joined with logical-Or, owners are also joined with
-// logical-OR. If other expressions are needed, please set the rules manually.
+// "_sign". Signers are joined with logical-Or, owners are joined with
+// logical-AND. If other expressions are needed, please set the rules manually.
 func InitRules(owners []*Identity, signers []*Identity) Rules {
 	rs := make(Rules)
 
@@ -64,7 +64,7 @@ func InitRules(owners []*Identity, signers []*Identity) Rules {
 	for i, o := range owners {
 		ownerIDs[i] = o.String()
 	}
-	rs[evolve] = expression.InitOrExpr(ownerIDs...)
+	rs[evolve] = expression.InitAndExpr(ownerIDs...)
 
 	signerIDs := make([]string, len(signers))
 	for i, s := range signers {

--- a/omniledger/darc/darc_test.go
+++ b/omniledger/darc/darc_test.go
@@ -20,7 +20,7 @@ func TestRules(t *testing.T) {
 	rules = InitRules(owners, []*Identity{})
 	expr, ok = rules[evolve]
 	require.True(t, ok)
-	require.Equal(t, string(expr), owners[0].String()+" | "+owners[1].String())
+	require.Equal(t, string(expr), owners[0].String()+" & "+owners[1].String())
 }
 
 func TestNewDarc(t *testing.T) {
@@ -325,17 +325,17 @@ func TestDarc_Delegation(t *testing.T) {
 	require.Nil(t, td3.darc.Rules.UpdateSign(td3.darc.Rules.GetEvolutionExpr()))
 	require.Nil(t, td4.darc.Rules.UpdateSign(td4.darc.Rules.GetEvolutionExpr()))
 
-	require.Nil(t, localEvolution(td2.darc, []*Darc{td1.darc}, td1.owners[0]))
+	require.Nil(t, localEvolution(td2.darc, []*Darc{td1.darc}, td1.owners...))
 	require.Nil(t, td2.darc.Verify())
 
-	require.Nil(t, localEvolution(td4.darc, []*Darc{td3.darc}, td3.owners[0]))
+	require.Nil(t, localEvolution(td4.darc, []*Darc{td3.darc}, td3.owners...))
 	require.Nil(t, td4.darc.Verify())
 
 	id3 := NewIdentityDarc(td3.darc.GetID())
 	d2Expr := []byte(id3.String())
 	require.Nil(t, td2.darc.Rules.UpdateEvolution(d2Expr))
 	require.NotNil(t, td2.darc.Verify())
-	require.Nil(t, localEvolution(td2.darc, []*Darc{td1.darc}, td1.owners[0]))
+	require.Nil(t, localEvolution(td2.darc, []*Darc{td1.darc}, td1.owners...))
 	require.Nil(t, td2.darc.Verify())
 
 	td5 := createDarc(2, "testdarc5")
@@ -354,7 +354,7 @@ func TestDarc_Delegation(t *testing.T) {
 	// td3.owners which is out of date.
 	require.NotNil(t, td5.darc.VerifyWithCB(getDarc))
 	// If the evolution is signed by the latest darc, then it's ok.
-	require.Nil(t, localEvolution(td5.darc, []*Darc{td1.darc, td2.darc}, td4.owners[0]))
+	require.Nil(t, localEvolution(td5.darc, []*Darc{td1.darc, td2.darc}, td4.owners...))
 	require.Nil(t, td5.darc.VerifyWithCB(getDarc))
 }
 

--- a/omniledger/service/api_test.go
+++ b/omniledger/service/api_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"gopkg.in/dedis/cothority.v2"
+	"gopkg.in/dedis/kyber.v2/util/key"
 	"gopkg.in/dedis/onet.v2"
 )
 
@@ -14,8 +15,9 @@ func TestClient_GetProof(t *testing.T) {
 	_, roster, _ := l.GenTree(3, true)
 	defer l.CloseAll()
 	defer closeQueues(l)
+	pair := key.NewKeyPair(cothority.Suite)
 	c := NewClient()
-	csr, err := c.CreateSkipchain(roster, Transaction{Key: []byte{1}})
+	csr, err := c.CreateGenesisBlock(roster, pair.Public)
 	require.Nil(t, err)
 
 	key := []byte{1, 2, 3, 4}

--- a/omniledger/service/messages.go
+++ b/omniledger/service/messages.go
@@ -5,6 +5,7 @@ This holds the messages used to communicate with the service over the network.
 */
 
 import (
+	"github.com/dedis/student_18_omniledger/omniledger/darc"
 	"gopkg.in/dedis/cothority.v2/skipchain"
 	"gopkg.in/dedis/onet.v2"
 	"gopkg.in/dedis/onet.v2/network"
@@ -13,15 +14,10 @@ import (
 // We need to register all messages so the network knows how to handle them.
 func init() {
 	network.RegisterMessages(
-		&CreateSkipchain{}, &CreateSkipchainResponse{},
+		&CreateGenesisBlock{}, &CreateGenesisBlockResponse{},
 		&SetKeyValue{}, &SetKeyValueResponse{},
 	)
 }
-
-const (
-	// ErrorParse indicates an error while parsing the protobuf-file.
-	ErrorParse = iota + 4000
-)
 
 // Version indicates what version this client runs. In the first development
 // phase, each next version will break the preceeding versions. Later on,
@@ -36,25 +32,26 @@ const CurrentVersion Version = 1
 // import "roster.proto";
 //
 // option java_package = "ch.epfl.dedis.proto";
-// option java_outer_classname = "LleapProto";
+// option java_outer_classname = "OmniLedgerProto";
 
 // ***
 // These are the messages used in the API-calls
 // ***
 
-// CreateSkipchain asks the cisc-service to set up a new skipchain.
-type CreateSkipchain struct {
+// CreateGenesisBlock asks the cisc-service to set up a new skipchain.
+type CreateGenesisBlock struct {
 	// Version of the protocol
 	Version Version
 	// Roster defines which nodes participate in the skipchain.
 	Roster onet.Roster
-	// Transaction contains the master darc which defines who is allowed to
-	// write to this skipchain. we will only store its hash.
-	Transaction Transaction
+	// Genesis Tx contains the initial configuration.
+	GenesisTx Transaction
+	// GenesisDarc defines who is allowed to write to this skipchain.
+	GenesisDarc darc.Darc
 }
 
-// CreateSkipchainResponse holds the genesis-block of the new skipchain.
-type CreateSkipchainResponse struct {
+// CreateGenesisBlockResponse holds the genesis-block of the new skipchain.
+type CreateGenesisBlockResponse struct {
 	// Version of the protocol
 	Version Version
 	// Skipblock of the created skipchain or empty if there was an error.

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -20,15 +20,13 @@ import (
 	"gopkg.in/satori/go.uuid.v1"
 
 	"github.com/dedis/student_18_omniledger/omniledger/collection"
+	"github.com/dedis/student_18_omniledger/omniledger/darc"
 )
 
 // Used for tests
+// TODO move to test
 var omniledgerID onet.ServiceID
 var verifyOmniledger = skipchain.VerifierID(uuid.NewV5(uuid.NamespaceURL, "Omniledger"))
-
-const keyMerkleRoot = "merkleroot"
-const keyNewKey = "newkey"
-const keyNewValue = "newvalue"
 
 func init() {
 	var err error
@@ -57,10 +55,8 @@ type Service struct {
 	propagateTransactions messaging.PropagationFunc
 
 	storage *storage
-}
 
-type queue struct {
-	transactions []Transaction
+	createSkipChainMut sync.Mutex
 }
 
 // storageID reflects the data we're storing - we could store more
@@ -82,30 +78,72 @@ type updateCollection struct {
 	ID skipchain.SkipBlockID
 }
 
-// CreateSkipchain asks the cisc-service to create a new skipchain ready to
+// CreateGenesisBlock asks the cisc-service to create a new skipchain ready to
 // store key/value pairs. If it is given exactly one writer, this writer will
 // be stored in the skipchain.
 // For faster access, all data is also stored locally in the Service.storage
 // structure.
-func (s *Service) CreateSkipchain(req *CreateSkipchain) (
-	*CreateSkipchainResponse, error) {
+func (s *Service) CreateGenesisBlock(req *CreateGenesisBlock) (
+	*CreateGenesisBlockResponse, error) {
+	// We use a big mutex here because we do not want to allow concurrent
+	// creation of genesis blocks.
+	// TODO an optimisation would be to lock on the skipchainID.
+	s.createSkipChainMut.Lock()
+	defer s.createSkipChainMut.Unlock()
+
 	if req.Version != CurrentVersion {
-		return nil, errors.New("version mismatch")
+		return nil, fmt.Errorf("version mismatch - got %d but need %d", req.Version, CurrentVersion)
+	}
+	if err := checkTx(req.GenesisDarc, req.GenesisTx); err != nil {
+		return nil, err
 	}
 
-	sb, err := s.createNewBlock(nil, &req.Roster, []Transaction{req.Transaction})
+	// Create the genesis-transaction with a special key, it acts as a
+	// reference to the actual genesis transaction.
+	genesisTx := Transaction{
+		Key:   []byte("genesis"),
+		Value: req.GenesisTx.Key,
+	}
+	darcBuf, err := req.GenesisDarc.ToProto()
+	if err != nil {
+		return nil, err
+	}
+	darcTx := Transaction{
+		Key:   req.GenesisDarc.GetID(),
+		Kind:  []byte("darc"),
+		Value: darcBuf,
+	}
+
+	sb, err := s.createNewBlock(nil, &req.Roster, []Transaction{darcTx, req.GenesisTx, genesisTx})
 	if err != nil {
 		return nil, err
 	}
 	s.save()
+
 	s.queueWorkers[string(sb.SkipChainID())], err = s.createQueueWorker(sb.SkipChainID())
 	if err != nil {
 		return nil, err
 	}
-	return &CreateSkipchainResponse{
+	return &CreateGenesisBlockResponse{
 		Version:   CurrentVersion,
 		Skipblock: sb,
 	}, nil
+}
+
+func checkTx(d darc.Darc, tx Transaction) error {
+	darcLen := len(d.GetID())
+	if len(tx.Key) < darcLen {
+		return errors.New("incorrect key length")
+	}
+	if !bytes.Equal(tx.Key[0:darcLen], d.GetID()) {
+		return errors.New("key is not the same as the darc ID")
+	}
+	if !bytes.Equal(tx.Kind, []byte("genesis")) {
+		return errors.New("kind must be \"genesis\"")
+	}
+	// TODO do the actual verification, need to figure out the relationship
+	// between a darc.Request and a Transaction
+	return nil
 }
 
 // SetKeyValue asks cisc to add a new key/value pair.
@@ -116,7 +154,7 @@ func (s *Service) SetKeyValue(req *SetKeyValue) (*SetKeyValueResponse, error) {
 
 	c, ok := s.queueWorkers[string(req.SkipchainID)]
 	if !ok {
-		return nil, errors.New("Don't know this skipchain")
+		return nil, fmt.Errorf("we don't know skipchain ID %x", req.SkipchainID)
 	}
 	c <- req.Transaction
 
@@ -393,7 +431,7 @@ func newService(c *onet.Context) (onet.Service, error) {
 		ServiceProcessor: onet.NewServiceProcessor(c),
 		CloseQueues:      make(chan bool),
 	}
-	if err := s.RegisterHandlers(s.CreateSkipchain, s.SetKeyValue,
+	if err := s.RegisterHandlers(s.CreateGenesisBlock, s.SetKeyValue,
 		s.GetProof); err != nil {
 		log.ErrFatal(err, "Couldn't register messages")
 	}

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -12,7 +12,6 @@ import (
 	"gopkg.in/dedis/kyber.v2/suites"
 	"gopkg.in/dedis/onet.v2"
 	"gopkg.in/dedis/onet.v2/log"
-	"gopkg.in/dedis/onet.v2/network"
 )
 
 var tSuite = suites.MustFind("Ed25519")
@@ -26,22 +25,28 @@ func TestService_CreateSkipchain(t *testing.T) {
 	s := newSer(t, 0)
 	defer s.local.CloseAll()
 	defer closeQueues(s.local)
-	resp, err := s.service.CreateSkipchain(&CreateSkipchain{
+	resp, err := s.service.CreateGenesisBlock(&CreateGenesisBlock{
 		Version: 0,
 		Roster:  *s.roster,
 	})
 	require.NotNil(t, err)
 
-	resp, err = s.service.CreateSkipchain(&CreateSkipchain{
-		Version: CurrentVersion,
-		Roster:  *s.roster,
-		Transaction: Transaction{
+	resp, err = s.service.CreateGenesisBlock(&CreateGenesisBlock{
+		Version:     CurrentVersion,
+		Roster:      *s.roster,
+		GenesisDarc: darc.Darc{},
+		GenesisTx: Transaction{
 			Key:   []byte("someKey"),
 			Kind:  []byte("someKind"),
 			Value: []byte("someValue"),
 		},
 	})
+	require.NotNil(t, err)
+
+	genesisMsg := DefaultGenesisMsg(CurrentVersion, s.roster)
+	resp, err = s.service.CreateGenesisBlock(&genesisMsg)
 	require.Nil(t, err)
+
 	assert.Equal(t, CurrentVersion, resp.Version)
 	assert.NotNil(t, resp.Skipblock)
 }
@@ -172,22 +177,13 @@ func newSer(t *testing.T, step int) *ser {
 	}
 	s.hosts, s.roster, _ = s.local.GenTree(5, true)
 	s.service = s.local.GetServices(s.hosts, omniledgerID)[0].(*Service)
-	s.darc = &darc.Darc{}
+	genesisMsg := DefaultGenesisMsg(CurrentVersion, s.roster)
+	s.darc = &genesisMsg.GenesisDarc
 
 	for i := 0; i < step; i++ {
 		switch i {
 		case 0:
-			d, err := network.Marshal(s.darc)
-			require.Nil(t, err)
-			resp, err := s.service.CreateSkipchain(&CreateSkipchain{
-				Version: CurrentVersion,
-				Roster:  *s.roster,
-				Transaction: Transaction{
-					Key:   s.darc.GetID(),
-					Kind:  []byte("darc"),
-					Value: d,
-				},
-			})
+			resp, err := s.service.CreateGenesisBlock(&genesisMsg)
 			require.Nil(t, err)
 			s.sb = resp.Skipblock
 		case 1:

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	bolt "github.com/coreos/bbolt"
-	"github.com/dedis/onet"
 	"github.com/dedis/student_18_omniledger/omniledger/collection"
 	"github.com/dedis/student_18_omniledger/omniledger/darc"
+	"gopkg.in/dedis/onet.v2"
 	"gopkg.in/dedis/onet.v2/network"
 )
 

--- a/omniledger/test.sh
+++ b/omniledger/test.sh
@@ -5,27 +5,30 @@ DBG_TEST=2
 DBG_APP=2
 DBG_SRV=2
 
-. $(go env GOPATH)/src/github.com/dedis/onet/app/libtest.sh
+. $(go env GOPATH)/src/gopkg.in/dedis/onet.v2/app/libtest.sh
 
 main(){
     startTest
-    buildConode
+    buildConode github.com/dedis/student_18_omniledger/omniledger/service
     test CreateStoreRead
     stopTest
 }
 
 testCreateStoreRead(){
-    runCoBG 1 2
-    runGrepSed ID "s/.* //" ./$APP create public.toml
+    pair=$(./"$APP" keypair)
+    pk=$(echo "$pair" | grep Public | sed 's/Public: //')
+    # sk=$(echo "$pair" | grep Private | sed 's/Private: //')
+    runCoBG 1 2 3
+    runGrepSed ID "s/.* //" ./"$APP" create public.toml "$pk"
     ID=$SED
-    echo ID is $ID
-    testOK runSicpa set public.toml $ID one two
-    testOK runSicpa get public.toml $ID one
-    testFail runSicpa get public.toml $ID two
+    echo ID is "$ID"
+    testOK runOmni set public.toml "$ID" one two
+    testOK runOmni get public.toml "$ID" one
+    testFail runOmni get public.toml "$ID" two
 }
 
-runSicpa(){
-    dbgRun ./$APP -d $DBG_APP $@
+runOmni(){
+    dbgRun ./"$APP" -d $DBG_APP "$@"
 }
 
 main


### PR DESCRIPTION
This PR refactors some of the existing code to support the creation of a genesis-darc and a genesis-transaction. The `CreateSkipchain` API got changed to `CreateGenesisBlock` and does the genesis block creation as described in https://github.com/dedis/student_18_omniledger/issues/18

The complete validation is not there yet, that is, we need a link between `Transaction` and `darc.Request` so that verification is as easy as calling `Darc.CheckRequest`. Further, it's unclear how the client (`app.go`) should specify the genesis configuration. These will be implemented in future PRs.