### PR TITLE
Move request verification from darc to request

### DIFF
--- a/omniledger/darc/darc.go
+++ b/omniledger/darc/darc.go
@@ -393,20 +393,11 @@ func (d *Darc) findPath(getDarc func(string) *Darc) error {
 	return nil
 }
 
-// CheckRequest checks the given request and returns an error if it cannot be
-// accepted. The caller is responsible for calling this function on the latest
-// darc.
-func (d Darc) CheckRequest(r *Request) error {
-	return d.CheckRequestWithCB(r, func(s string) *Darc {
-		return nil
-	})
-}
-
-// CheckRequestWithCB checks the given request using a callback which looks-up
-// missing darcs. The function returns an error if the request cannot be
-// accepted. The caller is responsible for calling this function on the latest
-// darc.
-func (d Darc) CheckRequestWithCB(r *Request, getDarc func(string) *Darc) error {
+// VerifyWithCB checks the request with the given darc using a callback which
+// looks-up missing darcs. The function returns an error if the request cannot
+// be accepted. The caller is responsible for providing the latest darc in the
+// argument.
+func (r *Request) VerifyWithCB(d *Darc, getDarc func(string) *Darc) error {
 	if !d.GetBaseID().Equal(r.BaseID) {
 		return fmt.Errorf("base id mismatch")
 	}
@@ -438,6 +429,15 @@ func (d Darc) CheckRequestWithCB(r *Request, getDarc func(string) *Darc) error {
 		return err
 	}
 	return nil
+}
+
+// Verify checks the request with the given darc and returns an error if it
+// cannot be accepted. The caller is responsible for providing  the latest
+// darc in the argument.
+func (r *Request) Verify(d *Darc) error {
+	return r.VerifyWithCB(d, func(s string) *Darc {
+		return nil
+	})
 }
 
 // String returns a human-readable string representation of the darc.

--- a/omniledger/darc/darc_example_test.go
+++ b/omniledger/darc/darc_example_test.go
@@ -30,16 +30,17 @@ func Example() {
 	// Client sends request r to the server, and the server must verify it.
 	// Usually the server will look in its database for the base ID of the
 	// darc in the request and find the latest one. But in this case we
-	// assume it already knows. If the check is successful, then the
+	// assume it already knows. If the verification is successful, then the
 	// server should add the darc in the request to its database.
-	fmt.Println(d1.CheckRequest(r))
+	fmt.Println(r.Verify(d1))
 	d2Server, _ := r.MsgToDarc([]*darc.Darc{d1}) // Server stores d2Server.
 	fmt.Println(bytes.Equal(d2Server.GetID(), d2.GetID()))
 
 	// If the darcs stored on the server are trustworthy, then using
-	// `CheckRequest` is enough. To do a complete verification, Darc.Verify
-	// should be used. This will traverse the chain of evolution and verify
-	// every evolution. However, the Darc.Path attribute must be set.
+	// `Request.Verify` is enough. To do a complete verification,
+	// Darc.Verify should be used. This will traverse the chain of
+	// evolution and verify every evolution. However, the Darc.Path
+	// attribute must be set.
 	fmt.Println(d2Server.Verify())
 
 	// The above illustrates the basic use of darcs, in the following
@@ -56,13 +57,13 @@ func Example() {
 	d3.Rules.AddRule(action3, expr3)
 
 	r, _ = darc.NewRequest(d3.GetID(), action3, []byte("example request"), owner3)
-	if err := d3.CheckRequest(r); err != nil {
+	if err := r.Verify(d3); err != nil {
 		// not ok because the expression is created using logical and
 		fmt.Println("not ok!")
 	}
 
 	r, _ = darc.NewRequest(d3.GetID(), action3, []byte("example request"), owner1, owner2, owner3)
-	if err := d3.CheckRequest(r); err == nil {
+	if err := r.Verify(d3); err == nil {
 		fmt.Println("ok!")
 	}
 

--- a/omniledger/darc/darc_test.go
+++ b/omniledger/darc/darc_test.go
@@ -236,45 +236,45 @@ func TestDarc_Rules(t *testing.T) {
 	// happy case with signer 1
 	r, err = NewRequest(d.GetID(), "use", []byte("secrets are lies"), user1)
 	require.Nil(t, err)
-	require.Nil(t, d.CheckRequest(r))
+	require.Nil(t, r.Verify(d))
 
 	// happy case with signer 2
 	r, err = NewRequest(d.GetID(), "use", []byte("sharing is caring"), user2)
 	require.Nil(t, err)
-	require.Nil(t, d.CheckRequest(r))
+	require.Nil(t, r.Verify(d))
 
 	// happy case with both signers
 	r, err = NewRequest(d.GetID(), "use", []byte("privacy is theft"), user1, user2)
 	require.Nil(t, err)
-	require.Nil(t, d.CheckRequest(r))
+	require.Nil(t, r.Verify(d))
 
 	// wrong ID
 	d2 := createDarc(1, "testdarc2").darc
 	r, err = NewRequest(d2.GetID(), "use", []byte("all animals are equal"), user1)
 	require.Nil(t, err)
-	require.NotNil(t, d.CheckRequest(r))
+	require.NotNil(t, r.Verify(d))
 
 	// wrong action
 	r, err = NewRequest(d.GetID(), "go", []byte("four legs good"), user1)
 	require.Nil(t, err)
-	require.NotNil(t, d.CheckRequest(r))
+	require.NotNil(t, r.Verify(d))
 
 	// wrong signer 1
 	user3 := NewSignerEd25519(nil, nil)
 	r, err = NewRequest(d.GetID(), "use", []byte("two legs bad"), user3)
 	require.Nil(t, err)
-	require.NotNil(t, d.CheckRequest(r))
+	require.NotNil(t, r.Verify(d))
 
 	// happy case where at least one signer is valid
 	r, err = NewRequest(d.GetID(), "use", []byte("four legs good"), user1, user3)
 	require.Nil(t, err)
-	require.Nil(t, d.CheckRequest(r))
+	require.Nil(t, r.Verify(d))
 
 	// tampered signature
 	r, err = NewRequest(d.GetID(), "use", []byte("two legs better"), user1, user3)
 	r.Signatures[0] = copyBytes(r.Signatures[1])
 	require.Nil(t, err)
-	require.NotNil(t, d.CheckRequest(r))
+	require.NotNil(t, r.Verify(d))
 }
 
 func TestDarc_EvolveRequest(t *testing.T) {
@@ -303,13 +303,13 @@ func TestDarc_EvolveRequest(t *testing.T) {
 	r, err = dNew.MakeEvolveRequest(badOwner)
 	require.Nil(t, err)
 	require.NotNil(t, r)
-	require.NotNil(t, td.darc.CheckRequest(r))
+	require.NotNil(t, r.Verify(td.darc))
 
 	// create the request with the right signer and it should pass
 	r, err = dNew.MakeEvolveRequest(td.owners[0])
 	require.Nil(t, err)
 	require.NotNil(t, r)
-	require.Nil(t, td.darc.CheckRequest(r))
+	require.Nil(t, r.Verify(td.darc))
 }
 
 // TestDarc_Delegation in this test we test delegation. We start with two


### PR DESCRIPTION
So that it's consistent with our other code, e.g. we often have Signature.Verify. This change prepares for transaction verification.