### PR TITLE
Flag transactions

### DIFF
--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -478,12 +478,22 @@ func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool
 		if !exists {
 			continue
 		}
-		validSB = validSB && f(cdb, &tx)
 		if tx.Valid != f(cdb, &tx) {
 			return false
 		}
 	}
 	return true
+}
+
+// validateTransactions set the valid-flag of the transaction according to the
+// registered OmniledgerVerifiers.
+func (s *Service) validateTransactions(cdb *collectionDB, txs []Transaction) {
+	for _, tx := range txs {
+		f, exists := s.verifiers[string(tx.Kind)]
+		if exists {
+			tx.Valid = f(cdb, &tx)
+		}
+	}
 }
 
 // RegisterVerification stores the verification in a map and will

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -464,7 +464,6 @@ func newService(c *onet.Context) (onet.Service, error) {
 // We use the omniledger as a receiver (as is done in the identity service),
 // so we can access e.g. the collectionDBs of the service.
 func (s *Service) verifySkipBlock(newID []byte, newSB *skipchain.SkipBlock) bool {
-	validSB = true
 	_, dataI, err := network.Unmarshal(newSB.Data, cothority.Suite)
 	data, ok := dataI.(*Data)
 	if err != nil || !ok {

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -231,10 +231,12 @@ func (s *Service) createNewBlock(scID skipchain.SkipBlockID, r *onet.Roster, ts 
 		if r != nil {
 			sb.Roster = r
 		}
-		mr, err = s.getCollection(scID).tryHash(ts)
+		cdb := s.getCollection(scID)
+		mr, err = cdb.tryHash(ts)
 		if err != nil {
 			return nil, errors.New("error while getting merkle root from collection: " + err.Error())
 		}
+		s.validateTransactions(cdb, ts)
 	}
 
 	data := &Data{

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -185,16 +185,6 @@ func TestService_DummyVerification(t *testing.T) {
 	require.NotNil(t, akvresp)
 	require.Equal(t, CurrentVersion, akvresp.Version)
 
-	time.Sleep(2 * waitQueueing)
-	pr, err := s.service.GetProof(&GetProof{
-		Version: CurrentVersion,
-		ID:      s.sb.SkipChainID(),
-		Key:     key1,
-	})
-	require.Nil(t, err)
-	match := pr.Proof.InclusionProof.Match()
-	require.False(t, match)
-
 	key2 := []byte("b")
 	value2 := []byte("b")
 	akvresp, err = s.service.SetKeyValue(&SetKeyValue{
@@ -212,6 +202,16 @@ func TestService_DummyVerification(t *testing.T) {
 	require.Equal(t, CurrentVersion, akvresp.Version)
 
 	time.Sleep(4 * waitQueueing)
+
+	pr, err := s.service.GetProof(&GetProof{
+		Version: CurrentVersion,
+		ID:      s.sb.SkipChainID(),
+		Key:     key1,
+	})
+	require.Nil(t, err)
+	match := pr.Proof.InclusionProof.Match()
+	require.False(t, match)
+
 	pr, err = s.service.GetProof(&GetProof{
 		Version: CurrentVersion,
 		ID:      s.sb.SkipChainID(),

--- a/omniledger/service/service_test.go
+++ b/omniledger/service/service_test.go
@@ -201,7 +201,7 @@ func TestService_DummyVerification(t *testing.T) {
 	require.NotNil(t, akvresp)
 	require.Equal(t, CurrentVersion, akvresp.Version)
 
-	time.Sleep(4 * waitQueueing)
+	time.Sleep(8 * waitQueueing)
 
 	pr, err := s.service.GetProof(&GetProof{
 		Version: CurrentVersion,
@@ -221,7 +221,6 @@ func TestService_DummyVerification(t *testing.T) {
 	match = pr.Proof.InclusionProof.Match()
 	require.True(t, match)
 
-	time.Sleep(4 * waitQueueing)
 }
 
 func verifyDummyKind(cdb *collectionDB, tx *Transaction) bool {

--- a/omniledger/service/struct.go
+++ b/omniledger/service/struct.go
@@ -158,6 +158,9 @@ type Transaction struct {
 	Key    []byte
 	Kind   []byte
 	Value  []byte
+	// The Valid flag is set IFF the corresponding verifier considers the
+	// transaction valid
+	Valid bool
 	// The signature is performed on the concatenation of the []bytes
 	Signature darc.Signature
 }


### PR DESCRIPTION
This PR fixes the second part of #31.

We add a `Valid` flag to `Transaction, which is set by `validateTransactions`.
`validateTransactions` essentially simulates the behavior of the verification function and sets the `Valid`flags accordingly. For the moment, we assume transactions stored in the genesis block are always valid.