### PR TITLE
Cleanup

### DIFF
--- a/omniledger/service/api_test.go
+++ b/omniledger/service/api_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestClient_GetProof(t *testing.T) {
 	l := onet.NewTCPTest(cothority.Suite)
-	_, roster, _ := l.GenTree(3, true)
+	servers, roster, _ := l.GenTree(3, true)
+	registerDummy(servers)
 	defer l.CloseAll()
 	defer closeQueues(l)
 	signer := darc.NewSignerEd25519(nil, nil)


### PR DESCRIPTION
Moved some methods around in `service.go`
* I want the last three methods to be: `tryLoad`, `save`, `newService`
* First all public API-methods of the service
* then any other public method on the service
* finally private methods
* methods not on service (except `newService`) should go into a different file
Created registration for dummy verification