### PR TITLE
Changing transaction types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.tags
+.tags*

--- a/omniledger/app.go
+++ b/omniledger/app.go
@@ -109,10 +109,13 @@ func set(c *cli.Context) error {
 	kind := c.Args().Get(3)
 	key := c.Args().Get(4)
 	value := c.Args().Get(5)
-	tx := service.Transaction{
-		Kind:  []byte(kind),
-		Key:   []byte(key),
-		Value: []byte(value),
+	tx := service.ClientTransaction{
+		Instructions: []service.Instruction{{
+			DarcID: darc.ID(key[0:32]),
+			Nonce:  []byte(key[32:]),
+			Kind:   kind,
+			Data:   []byte(value),
+		}},
 	}
 	_, err = service.NewClient().SetKeyValue(group.Roster, scid, tx)
 	if err != nil {

--- a/omniledger/service/api_test.go
+++ b/omniledger/service/api_test.go
@@ -26,12 +26,15 @@ func TestClient_GetProof(t *testing.T) {
 
 	key := []byte{1, 2, 3, 4}
 	value := []byte{5, 6, 7, 8}
-	kind := []byte("dummy")
+	kind := "dummy"
 	_, err = c.SetKeyValue(roster, csr.Skipblock.SkipChainID(),
-		Transaction{
-			Key:   key,
-			Kind:  kind,
-			Value: value,
+		ClientTransaction{
+			Instructions: []Instruction{{
+				DarcID:  key,
+				Command: "Create",
+				Kind:    kind,
+				Data:    value,
+			}},
 		})
 	require.Nil(t, err)
 

--- a/omniledger/service/classes.go
+++ b/omniledger/service/classes.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/dedis/protobuf"
+	"github.com/dedis/student_18_omniledger/omniledger/collection"
+	"github.com/dedis/student_18_omniledger/omniledger/darc"
+	"gopkg.in/dedis/onet.v2/log"
+)
+
+// Here we give a definition of pre-defined classe.
+
+// CmdCreate is the only command that is pre-defined.
+var CmdCreate = "Create"
+
+// ConfigID is 32 bytes of zeroes.
+var ConfigID = make([]byte, 32)
+
+// ZeroNonce is 32 bytes of zeroes and can have a special meaning.
+var ZeroNonce = make([]byte, 32)
+
+// KindConfig denotes a config-class
+var KindConfig = "config"
+
+// ClassConfig can only be instantiated once per skipchain, and that only for
+// the genesis block.
+func (s *Service) ClassConfig(cdb collection.Collection, tx Instruction, kind string, state []byte) ([]StateChange, error) {
+	switch tx.Command {
+	case CmdCreate:
+		darc := &darc.Darc{}
+		err := protobuf.Decode(tx.Data, darc)
+		if err != nil {
+			log.Error("couldn't get darc")
+			return nil, err
+		}
+		if err = darc.Verify(); err != nil {
+			log.Error("couldn't verify darc")
+			return nil, err
+		}
+		if len(darc.Rules) == 0 {
+			return nil, errors.New("don't accept darc with empty rules")
+		}
+		return []StateChange{
+			NewStateChange(Create, ConfigID, nil, KindConfig, tx.DarcID),
+			NewStateChange(Create, tx.DarcID, nil, KindDarc, tx.Data),
+		}, nil
+	default:
+		return nil, errors.New("Unknown command")
+	}
+}
+
+// KindDarc denotes a darc-class
+var KindDarc = "darc"
+
+// CmdDarcEvolve is needed to evolve a darc.
+var CmdDarcEvolve = "Evolve"
+
+// ClassDarc has the following methods:
+//   - Create - creates a new darc
+//   - Evolve - evolves an existing darc
+func (s *Service) ClassDarc(cdb collection.Collection, tx Instruction, kind string, state []byte) ([]StateChange, error) {
+	switch tx.Command {
+	case CmdCreate:
+		return nil, errors.New("Not yet implemented")
+	case CmdDarcEvolve:
+		return nil, errors.New("Not yet implemented")
+	default:
+		return nil, errors.New("Unknown command")
+	}
+}

--- a/omniledger/service/messages.go
+++ b/omniledger/service/messages.go
@@ -44,8 +44,6 @@ type CreateGenesisBlock struct {
 	Version Version
 	// Roster defines which nodes participate in the skipchain.
 	Roster onet.Roster
-	// Genesis Tx contains the initial configuration.
-	GenesisTx Transaction
 	// GenesisDarc defines who is allowed to write to this skipchain.
 	GenesisDarc darc.Darc
 }
@@ -66,7 +64,7 @@ type SetKeyValue struct {
 	// SkipchainID is the hash of the first skipblock
 	SkipchainID skipchain.SkipBlockID
 	// Transaction to be apllied to the kv-store
-	Transaction Transaction
+	Transaction ClientTransaction
 }
 
 // SetKeyValueResponse gives the timestamp and the skipblock-id

--- a/omniledger/service/proof.go
+++ b/omniledger/service/proof.go
@@ -67,9 +67,9 @@ func NewProof(c *collectionDB, s *skipchain.SkipBlockDB, id skipchain.SkipBlockI
 // is not properly set up.
 var ErrorVerifyCollection = errors.New("collection inclusion proof is wrong")
 
-// ErrorVerifyMerkleRoot is returned if the root of the collection
+// ErrorVerifyCollectionRoot is returned if the root of the collection
 // is different than the stored value in the skipblock.
-var ErrorVerifyMerkleRoot = errors.New("root of collection is not in skipblock")
+var ErrorVerifyCollectionRoot = errors.New("root of collection is not in skipblock")
 
 // ErrorVerifySkipchain is returned if the stored skipblock doesn't
 // have a proper proof that it comes from the genesis block.
@@ -87,8 +87,8 @@ func (p Proof) Verify(scID skipchain.SkipBlockID) error {
 	if err != nil {
 		return err
 	}
-	if !bytes.Equal(p.InclusionProof.TreeRootHash(), d.(*Data).MerkleRoot) {
-		return ErrorVerifyMerkleRoot
+	if !bytes.Equal(p.InclusionProof.TreeRootHash(), d.(*DataHeader).CollectionRoot) {
+		return ErrorVerifyCollectionRoot
 	}
 	var sbID skipchain.SkipBlockID
 	var publics []kyber.Point

--- a/omniledger/service/proof_test.go
+++ b/omniledger/service/proof_test.go
@@ -43,11 +43,11 @@ func TestVerify(t *testing.T) {
 
 	require.Equal(t, ErrorVerifySkipchain, p.Verify(s.genesis2.SkipChainID()))
 
-	p.Latest.Data, err = network.Marshal(&Data{
-		MerkleRoot: getSBID("123"),
+	p.Latest.Data, err = network.Marshal(&DataHeader{
+		CollectionRoot: getSBID("123"),
 	})
 	require.Nil(t, err)
-	require.Equal(t, ErrorVerifyMerkleRoot, p.Verify(s.genesis.SkipChainID()))
+	require.Equal(t, ErrorVerifyCollectionRoot, p.Verify(s.genesis.SkipChainID()))
 }
 
 type sc struct {
@@ -91,7 +91,7 @@ func createSC(t *testing.T) (s sc) {
 
 	s.key = []byte("key")
 	s.value = []byte("value")
-	s.c.Store(&Transaction{Key: s.key, Value: s.value})
+	s.c.Store(&StateChange{Action: Create, Key: s.key, Value: s.value})
 
 	s.genesis = skipchain.NewSkipBlock()
 	s.genesis.Roster, s.genesisPrivs = genRoster(1)
@@ -99,8 +99,8 @@ func createSC(t *testing.T) (s sc) {
 
 	s.sb2 = skipchain.NewSkipBlock()
 	s.sb2.Roster, _ = genRoster(2)
-	s.sb2.Data, err = network.Marshal(&Data{
-		MerkleRoot: s.c.RootHash(),
+	s.sb2.Data, err = network.Marshal(&DataHeader{
+		CollectionRoot: s.c.RootHash(),
 	})
 	require.Nil(t, err)
 	s.sb2.Hash = s.sb2.CalculateHash()

--- a/omniledger/service/transaction.go
+++ b/omniledger/service/transaction.go
@@ -2,42 +2,171 @@ package service
 
 import (
 	"crypto/sha256"
-	"encoding/binary"
 	"errors"
+	"fmt"
 
+	"github.com/dedis/student_18_omniledger/omniledger/collection"
 	"github.com/dedis/student_18_omniledger/omniledger/darc"
+	"gopkg.in/dedis/onet.v2/network"
 )
 
+func init() {
+	network.RegisterMessages(Instruction{}, ClientTransaction{},
+		OmniledgerTransaction{}, StateChange{})
+}
+
+// Instruction is created by a client. It has the following format:
+type Instruction struct {
+	// DarcID points to the darc that can verify the signature
+	DarcID darc.ID
+	// Nonce: will be concatenated to the darcID to create the key
+	Nonce []byte
+	// Command is object-specific and case-sensitive. The only command common to
+	// all classes is "Create".
+	Command string
+	// Kind is only used when the command is "Create"
+	Kind string `proto:"opt"`
+	// Data is a free slice of bytes that can be sent to the object.
+	Data []byte
+	// Signatures that can be verified using the given darcID
+	Signatures []darc.Signature
+}
+
 // Hash computes the digest of the hash function
-func (tx Transaction) Hash() []byte {
+func (instr Instruction) Hash() []byte {
 	h := sha256.New()
-	if tx.Action != 0 {
-		b := make([]byte, 4)
-		binary.LittleEndian.PutUint32(b, uint32(tx.Action))
-		h.Write(b)
-	}
-	h.Write(tx.Key)
-	h.Write(tx.Kind)
-	h.Write(tx.Value)
+	h.Write(instr.DarcID)
+	h.Write(instr.Nonce)
+	h.Write([]byte(instr.Command))
+	h.Write([]byte(instr.Kind))
+	h.Write(instr.Data)
 	return h.Sum(nil)
 }
 
 // ToDarcRequest converts the Transaction content into a darc.Request.
-func (tx Transaction) ToDarcRequest() (*darc.Request, error) {
-	if len(tx.Key) < darcIDLen {
+func (instr Instruction) ToDarcRequest(kind string) (*darc.Request, error) {
+	if len(instr.DarcID) < darcIDLen {
 		return nil, errors.New("incorrect transaction length")
 	}
-	baseID := tx.Key[0:32]
-	action := string(tx.Kind)
-	if tx.Action != 0 {
-		action += "_" + tx.Action.String()
-	}
-	ids := make([]*darc.Identity, len(tx.Signatures))
-	sigs := make([][]byte, len(tx.Signatures))
-	for i, sig := range tx.Signatures {
+	baseID := instr.DarcID
+	action := kind
+	ids := make([]*darc.Identity, len(instr.Signatures))
+	sigs := make([][]byte, len(instr.Signatures))
+	for i, sig := range instr.Signatures {
 		ids[i] = &sig.Signer
 		sigs[i] = sig.Signature // TODO shallow copy is ok?
 	}
-	req := darc.InitRequest(baseID, darc.Action(action), tx.Hash(), ids, sigs)
+	req := darc.InitRequest(baseID, darc.Action(action), instr.Hash(), ids, sigs)
 	return &req, nil
+}
+
+// GetKindState searches for the kind of this instruction. It needs the collection
+// to do so.
+func (instr Instruction) GetKindState(coll collection.Collection) (kind string, state []byte, err error) {
+	// Getting the kind is different for instructions that create a key
+	// and for instructions that send a call to an existing key.
+	if instr.Command == "Create" {
+		// For new key creations it is easy, as the first call needs to be
+		// "Create" with the kind given in the data.
+		return instr.Kind, nil, nil
+	}
+
+	// For existing keys, we need to go look the kind up in our database
+	// to find the kind.
+	kv := coll.Get(instr.GetKey())
+	var record collection.Record
+	record, err = kv.Record()
+	if err != nil {
+		return
+	}
+	var kindValue []interface{}
+	kindValue, err = record.Values()
+	if err != nil {
+		return
+	}
+	kind = string(kindValue[0].([]byte))
+	state = kindValue[1].([]byte)
+	return
+}
+
+// GetKey returns the DarcID concatenated with the nonce.
+func (instr Instruction) GetKey() []byte {
+	return append(instr.DarcID, instr.Nonce...)
+}
+
+// ClientTransaction is a slice of Instructions that will be applied in order.
+// If any of the instructions fails, none of them will be applied.
+type ClientTransaction struct {
+	Instructions []Instruction
+}
+
+// StateChange is one new state that will be applied to the collection.
+type StateChange struct {
+	// Action can be any of Create, Update, Remove
+	Action Action
+	// Key is the darcID concatenated with the Nonce
+	Key []byte
+	// Kind points to the class that can interpret the value
+	Kind []byte
+	// Value is the data needed by the class
+	Value []byte
+	// Previous points to the blockID of the previous StateChange for this Key
+	Previous []byte
+}
+
+// NewStateChange is a convenience function that fills out a StateChange
+// structure. For the moment it ignores previous. If a nil-nonce is given,
+// it will be filled with 32 0 bytes.
+func NewStateChange(a Action, darcid, nonce []byte, kind string, value []byte) StateChange {
+	if nonce == nil {
+		nonce = make([]byte, 32)
+	}
+	return StateChange{
+		Action: a,
+		Key:    append(darcid, nonce...),
+		Kind:   []byte(kind),
+		Value:  value,
+	}
+}
+
+// String can be used in print.
+func (sc StateChange) String() string {
+	return fmt.Sprintf("%s(%s): %x / %x", sc.Action, sc.Kind, sc.Key, sc.Value)
+}
+
+// Action describes how the collectionDB will be modified.
+type Action int
+
+const (
+	// Create allows to insert a new key-value association.
+	Create Action = iota + 1
+	// Update allows to change the value of an existing key.
+	Update
+	// Remove allows to delete an existing key-value association.
+	Remove
+)
+
+// String returns a readable output of the action.
+func (a Action) String() string {
+	switch a {
+	case Create:
+		return "create"
+	case Update:
+		return "update"
+	case Remove:
+		return "remove"
+	default:
+		return "invalid action"
+	}
+}
+
+// OmniledgerTransaction combines ClientTransactions and their StateChange. Plus
+// it indicates if the leader thinks this transaction is valid or not.
+type OmniledgerTransaction struct {
+	// ClientTransaction is one transaction from the client.
+	ClientTransaction ClientTransaction
+	// StateChanges are the resulting changes in the global state
+	StateChanges []StateChange
+	// Valid is set by the leader
+	Valid bool
 }


### PR DESCRIPTION
As described in the service/README.md, we propose the following transaction types:
- Instruction - is sent by the client
- ClientTransaction - holds one or more Instructions that are applied atomically or rejected in block
- OmnilegerTransaction - contains one ClientTransaction and a StateChange
- StateChange - describes one update of our collection

All previous tests pass, but no new tests have been added...