### PR TITLE
Only store digest in Request.Msg

### DIFF
--- a/omniledger/README.md
+++ b/omniledger/README.md
@@ -297,13 +297,22 @@ message Darc {
 	bytes BaseID = 3;
 	// Rules map an action to an expression.
 	Rules Rules = 4;
-	// Signature is calculated over the protobuf representation of [Rules, Version, Description]
-	// and needs to be created by an Owner from the previous valid Darc.
-	bytes Signature = 5;
+	// Path represents the path to get up to information to be able to
+	// verify this signature. These justify the right of the signer to push
+	// a new Darc. These are ordered from the oldest to the newest, i.e.
+	// Path[0] should be the base Darc. This field is optional unless
+	// offline verification is needed.
+	repeated Darc Path
+	// PathDigest is the digest that represent the path above.
+	bytes PathDigest = 5
+	// Signature is calculated on the Request-representation of the darc.
+	// It needs to be created by identities that have the "_evolve" action
+	// from the previous valid Darc.
+	repeated bytes Signature = 6;
 }
 
 message Rule {
-  map<string, bytes> Rules = 1;
+	map<string, bytes> Rules = 1;
 }
 ```
 

--- a/omniledger/darc/struct.go
+++ b/omniledger/darc/struct.go
@@ -53,13 +53,14 @@ type Darc struct {
 	// Represents the path to get up to information to be able to verify
 	// this signature.  These justify the right of the signer to push a new
 	// Darc.  These are ordered from the oldest to the newest, i.e.
-	// Darcs[0] should be the base Darc.
+	// Path[0] should be the base Darc.
 	Path []*Darc
-	// PathDigest should be set when Path has length 0. It should be the
-	// same as the return value of GetPathMsg.
+	// PathDigest is the digest of Path, it should be set when Path has
+	// length 0.
 	PathDigest []byte
-	// Signature is calculated over the protobuf representation of [Rules, Version, Description]
-	// and needs to be created by an Owner from the previous valid Darc.
+	// Signature is calculated on the Request-representation of the darc.
+	// It needs to be created by identities that have the "_evolve" action
+	// from the previous valid Darc.
 	Signatures []*Signature
 }
 
@@ -72,7 +73,8 @@ type Action string
 // Rules are action-expression associations.
 type Rules map[Action]expression.Expr
 
-// Identity is a generic structure can be either an Ed25519 public key or a Darc
+// Identity is a generic structure can be either an Ed25519 public key, a Darc
+// or a X509 Identity.
 type Identity struct {
 	// Darc identity
 	Darc *IdentityDarc
@@ -80,7 +82,6 @@ type Identity struct {
 	Ed25519 *IdentityEd25519
 	// Public-key identity
 	X509EC *IdentityX509EC
-	// Add information re. where the identity is from?
 }
 
 // IdentityEd25519 holds a Ed25519 public key (Point)
@@ -133,7 +134,6 @@ type innerRequest struct {
 	Action     Action
 	Msg        []byte
 	Identities []*Identity
-	// TODO add the darc for where the identities should come from, e.g. SignerDarcs []string
 }
 
 // Request is the structure that the client must provide to be verified

--- a/omniledger/service/transaction.go
+++ b/omniledger/service/transaction.go
@@ -208,10 +208,7 @@ func (instr *Instruction) SignBy(signers ...*darc.Signer) error {
 	}
 
 	// Sign the instruction and write the signatures to it.
-	digest, err := req.Hash()
-	if err != nil {
-		return err
-	}
+	digest := req.Hash()
 	instr.Signatures = make([]darc.Signature, len(signers))
 	for i := range signers {
 		sig, err := signers[i].Sign(digest)


### PR DESCRIPTION
Instead of using the Msg attribute of Request to store the actual
payload, we store a digest instead. This is to better support omniledger
because the actual darc will be stored in an omniledger transaction. We
also add some documentation fixes.