### PR TITLE
Store block interval in genesis block

### DIFF
--- a/omniledger/service/api.go
+++ b/omniledger/service/api.go
@@ -84,9 +84,10 @@ func DefaultGenesisMsg(v Version, r *onet.Roster, rules []string, ids ...*darc.I
 	}
 
 	m := CreateGenesisBlock{
-		Version:     v,
-		Roster:      *r,
-		GenesisDarc: *d,
+		Version:       v,
+		Roster:        *r,
+		GenesisDarc:   *d,
+		BlockInterval: defaultInterval,
 	}
 	return &m, nil
 }

--- a/omniledger/service/api_test.go
+++ b/omniledger/service/api_test.go
@@ -20,6 +20,7 @@ func TestClient_GetProof(t *testing.T) {
 	// Initialise the genesis message and send it to the service.
 	signer := darc.NewSignerEd25519(nil, nil)
 	msg, err := DefaultGenesisMsg(CurrentVersion, roster, []string{"Spawn_dummy"}, signer.Identity())
+	msg.BlockInterval = 100 * time.Millisecond
 	require.Nil(t, err)
 
 	// The darc inside it should be valid.
@@ -42,7 +43,7 @@ func TestClient_GetProof(t *testing.T) {
 	var p *GetProofResponse
 	var i int
 	for i = 0; i < 10; i++ {
-		time.Sleep(4 * waitQueueing)
+		time.Sleep(4 * msg.BlockInterval)
 		var err error
 		p, err = c.GetProof(roster, csr.Skipblock.SkipChainID(), tx.Instructions[0].ObjectID.Slice())
 		if err != nil {

--- a/omniledger/service/contracts.go
+++ b/omniledger/service/contracts.go
@@ -1,8 +1,11 @@
 package service
 
 import (
+	"encoding/binary"
 	"errors"
+	"time"
 
+	"github.com/dedis/protobuf"
 	"github.com/dedis/student_18_omniledger/omniledger/collection"
 	"github.com/dedis/student_18_omniledger/omniledger/darc"
 	"gopkg.in/dedis/onet.v2/log"
@@ -13,14 +16,29 @@ import (
 // ZeroNonce is 32 bytes of zeroes and can have a special meaning.
 var ZeroNonce = Nonce([32]byte{})
 
+// OneNonce has 32 bytes of zeros except the LSB is set to one.
+var OneNonce = Nonce(func() [32]byte {
+	var nonce [32]byte
+	nonce[31] = 1
+	return nonce
+}())
+
 // ZeroDarc is a DarcID with all zeroes.
 var ZeroDarc = darc.ID(make([]byte, 32))
 
-// ConfigID is 64 bytes of zeroes.
-var ConfigID = ObjectID{ZeroDarc, ZeroNonce}
+// GenesisReferenceID is 64 bytes of zeroes. Its value is a reference to the
+// genesis-darc.
+var GenesisReferenceID = ObjectID{ZeroDarc, ZeroNonce}
 
 // ContractConfigID denotes a config-contract
 var ContractConfigID = "config"
+
+// Config stores all the configuration information for one skipchain. It will
+// be stored under the key "GenesisDarcID || OneNonce", in the collections. The
+// GenesisDarcID is the value of GenesisReferenceID.
+type Config struct {
+	BlockInterval time.Duration
+}
 
 // ContractConfig can only be instantiated once per skipchain, and only for
 // the genesis block.
@@ -41,9 +59,32 @@ func (s *Service) ContractConfig(cdb collection.Collection, tx Instruction, coin
 		log.Error("couldn't verify darc")
 		return
 	}
+
+	// sanity check the block interval
+	intervalBuf := tx.Spawn.Args.Search("block_interval")
+	interval, _ := binary.Varint(intervalBuf)
+	if interval == 0 {
+		err = errors.New("block interval is zero")
+		return
+	}
+
+	// create the config to be stored by state changes
+	config := Config{
+		BlockInterval: time.Duration(interval),
+	}
+	configBuf, err := protobuf.Encode(&config)
+	if err != nil {
+		return
+	}
+
 	return []StateChange{
-		NewStateChange(Create, ConfigID, ContractConfigID, tx.ObjectID.DarcID),
+		NewStateChange(Create, GenesisReferenceID, ContractConfigID, tx.ObjectID.DarcID),
 		NewStateChange(Create, tx.ObjectID, ContractDarcID, darcBuf),
+		NewStateChange(Create,
+			ObjectID{
+				DarcID:     tx.ObjectID.DarcID,
+				InstanceID: OneNonce,
+			}, ContractDarcID, configBuf),
 	}, nil, nil
 }
 

--- a/omniledger/service/contracts.go
+++ b/omniledger/service/contracts.go
@@ -33,6 +33,12 @@ var GenesisReferenceID = ObjectID{ZeroDarc, ZeroNonce}
 // ContractConfigID denotes a config-contract
 var ContractConfigID = "config"
 
+// ContractDarcID denotes a darc-contract
+var ContractDarcID = "darc"
+
+// CmdDarcEvolve is needed to evolve a darc.
+var CmdDarcEvolve = "Evolve"
+
 // Config stores all the configuration information for one skipchain. It will
 // be stored under the key "GenesisDarcID || OneNonce", in the collections. The
 // GenesisDarcID is the value of GenesisReferenceID.
@@ -84,15 +90,9 @@ func (s *Service) ContractConfig(cdb collection.Collection, tx Instruction, coin
 			ObjectID{
 				DarcID:     tx.ObjectID.DarcID,
 				InstanceID: OneNonce,
-			}, ContractDarcID, configBuf),
+			}, ContractConfigID, configBuf),
 	}, nil, nil
 }
-
-// ContractDarcID denotes a darc-contract
-var ContractDarcID = "darc"
-
-// CmdDarcEvolve is needed to evolve a darc.
-var CmdDarcEvolve = "Evolve"
 
 // ContractDarc accepts the following instructions:
 //   - Spawn - creates a new darc

--- a/omniledger/service/messages.go
+++ b/omniledger/service/messages.go
@@ -5,6 +5,8 @@ This holds the messages used to communicate with the service over the network.
 */
 
 import (
+	"time"
+
 	"github.com/dedis/student_18_omniledger/omniledger/darc"
 	"gopkg.in/dedis/cothority.v2/skipchain"
 	"gopkg.in/dedis/onet.v2"
@@ -46,6 +48,8 @@ type CreateGenesisBlock struct {
 	Roster onet.Roster
 	// GenesisDarc defines who is allowed to write to this skipchain.
 	GenesisDarc darc.Darc
+	// BlockInterval in int64.
+	BlockInterval time.Duration
 }
 
 // CreateGenesisBlockResponse holds the genesis-block of the new skipchain.

--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -3,6 +3,7 @@ package service
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"sync"
@@ -17,6 +18,7 @@ import (
 	"gopkg.in/dedis/onet.v2/network"
 	"gopkg.in/satori/go.uuid.v1"
 
+	"github.com/dedis/protobuf"
 	"github.com/dedis/student_18_omniledger/omniledger/collection"
 	"github.com/dedis/student_18_omniledger/omniledger/darc"
 )
@@ -73,8 +75,9 @@ type Service struct {
 // than one structure.
 const storageID = "main"
 
-// TODO: this should go into the genesis-configuration
-var waitQueueing = 5 * time.Second
+// defaultInterval is used if the BlockInterval field in the genesis
+// trnasaction is not set.
+var defaultInterval = 5 * time.Second
 
 // storage is used to save our data locally.
 type storage struct {
@@ -114,9 +117,18 @@ func (s *Service) CreateGenesisBlock(req *CreateGenesisBlock) (
 		return nil, errors.New("invalid genesis darc")
 	}
 
+	if req.BlockInterval == 0 {
+		req.BlockInterval = defaultInterval
+	}
+	intervalBuf := make([]byte, 8)
+	binary.PutVarint(intervalBuf, int64(req.BlockInterval))
+
 	spawn := &Spawn{
 		ContractID: ContractConfigID,
-		Args:       Arguments{{Name: "darc", Value: darcBuf}},
+		Args: Arguments{
+			{Name: "darc", Value: darcBuf},
+			{Name: "block_interval", Value: intervalBuf},
+		},
 	}
 
 	// Create the genesis-transaction with a special key, it acts as a
@@ -138,7 +150,7 @@ func (s *Service) CreateGenesisBlock(req *CreateGenesisBlock) (
 	s.save()
 
 	s.workersMu.Lock()
-	s.queueWorkers[string(sb.SkipChainID())] = s.createQueueWorker(sb.SkipChainID())
+	s.queueWorkers[string(sb.SkipChainID())] = s.createQueueWorker(sb.SkipChainID(), req.BlockInterval)
 	s.workersMu.Unlock()
 
 	return &CreateGenesisBlockResponse{
@@ -207,22 +219,6 @@ func padKey(key []byte) []byte {
 	return keyPadded
 }
 
-func (s *Service) getLatestDarcByID(sid skipchain.SkipBlockID, dID darc.ID) (*darc.Darc, error) {
-	colldb := s.getCollection(sid)
-	if colldb == nil {
-		return nil, fmt.Errorf("collection for skipchain ID %s does not exist", sid.Short())
-	}
-	value, contract, err := colldb.GetValueContract(padKey(dID))
-	if err != nil {
-		return nil, err
-	}
-	if string(contract) != "darc" {
-		return nil, fmt.Errorf("for darc %x, expected Kind to be 'darc' but got '%v'", dID, string(contract))
-	}
-	// TODO we need to make sure this darc is the latest
-	return darc.NewDarcFromProto(value)
-}
-
 func (s *Service) verifyAndFilterTxs(scID skipchain.SkipBlockID, ts []ClientTransaction) []ClientTransaction {
 	var validTxs []ClientTransaction
 	for _, t := range ts {
@@ -245,7 +241,7 @@ func (s *Service) verifyClientTx(scID skipchain.SkipBlockID, tx ClientTransactio
 }
 
 func (s *Service) verifyInstruction(scID skipchain.SkipBlockID, instr Instruction) error {
-	d, err := s.getLatestDarcByID(scID, instr.ObjectID.DarcID)
+	d, err := s.loadLatestDarc(scID, instr.ObjectID.DarcID)
 	if err != nil {
 		return err
 	}
@@ -421,13 +417,69 @@ func (s *Service) db() *skipchain.SkipBlockDB {
 	return s.skService().GetDB()
 }
 
+func (s *Service) loadConfig(scID skipchain.SkipBlockID) (*Config, error) {
+	coll := s.getCollection(scID)
+	// Find the genesis-darc ID.
+	val, contract, err := coll.GetValueContract(GenesisReferenceID.Slice())
+	if err != nil {
+		return nil, err
+	}
+	if string(contract) != ContractConfigID {
+		return nil, errors.New("did not get " + ContractConfigID)
+	}
+	if len(val) != 64 {
+		return nil, errors.New("value has a invalid length")
+	}
+	// Use the genesis-darc ID to create the config key and read the config.
+	configID := ObjectID{
+		DarcID:     darc.ID(val[:32]),
+		InstanceID: OneNonce,
+	}
+	val, contract, err = coll.GetValueContract(configID.Slice())
+	if err != nil {
+		return nil, err
+	}
+	if string(contract) != ContractConfigID {
+		return nil, errors.New("did not get " + ContractConfigID)
+	}
+	config := Config{}
+	err = protobuf.Decode(val, &config)
+	if err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+func (s *Service) loadBlockInterval(scID skipchain.SkipBlockID) (time.Duration, error) {
+	config, err := s.loadConfig(scID)
+	if err != nil {
+		return defaultInterval, err
+	}
+	return config.BlockInterval, nil
+}
+
+func (s *Service) loadLatestDarc(sid skipchain.SkipBlockID, dID darc.ID) (*darc.Darc, error) {
+	colldb := s.getCollection(sid)
+	if colldb == nil {
+		return nil, fmt.Errorf("collection for skipchain ID %s does not exist", sid.Short())
+	}
+	value, contract, err := colldb.GetValueContract(padKey(dID))
+	if err != nil {
+		return nil, err
+	}
+	if string(contract) != "darc" {
+		return nil, fmt.Errorf("for darc %x, expected Kind to be 'darc' but got '%v'", dID, string(contract))
+	}
+	return darc.NewDarcFromProto(value)
+}
+
 // createQueueWorker sets up a worker that will listen on a channel for
 // incoming requests and then create a new block every epoch.
-func (s *Service) createQueueWorker(scID skipchain.SkipBlockID) chan ClientTransaction {
+func (s *Service) createQueueWorker(scID skipchain.SkipBlockID, interval time.Duration) chan ClientTransaction {
 	c := make(chan ClientTransaction)
 	go func() {
 		ts := []ClientTransaction{}
-		to := time.After(waitQueueing)
+		to := time.After(interval)
 		for {
 			select {
 			case t := <-c:
@@ -445,11 +497,11 @@ func (s *Service) createQueueWorker(scID skipchain.SkipBlockID) chan ClientTrans
 					ts = []ClientTransaction{}
 					if err != nil {
 						log.Error("couldn't create new block: " + err.Error())
-						to = time.After(waitQueueing)
+						to = time.After(interval)
 						continue
 					}
 				}
-				to = time.After(waitQueueing)
+				to = time.After(interval)
 			case <-s.CloseQueues:
 				log.Lvlf2("closing queues...")
 				return
@@ -578,10 +630,13 @@ func (s *Service) tryLoad() error {
 	}
 
 	for _, sb := range gasr.SkipChains {
-		s.getCollection(sb.Hash)
+		interval, err := s.loadBlockInterval(sb.Hash)
+		if err != nil {
+			return err
+		}
 		// At this point the service is not yet up, so no need to
 		// protect access to queueWorkers with a mutex.
-		s.queueWorkers[string(sb.Hash)] = s.createQueueWorker(sb.Hash)
+		s.queueWorkers[string(sb.Hash)] = s.createQueueWorker(sb.Hash, interval)
 	}
 
 	return nil


### PR DESCRIPTION
Store block interval in genesis configuration so that applications, such as eventlog, can set their own block intervals. 