### PR TITLE
Update collection state with state changes

### DIFF
--- a/omniledger/service/service.go
+++ b/omniledger/service/service.go
@@ -582,10 +582,14 @@ clientTransactions:
 			scs, _, err := f(cdbI, instr, nil)
 			if err != nil {
 				log.Lvl1("Call to contract returned error:", err)
-				cdbI = cdbTemp
 				continue clientTransactions
 			}
-			// TODO: apply new state
+			for _, sc := range scs {
+				if err := storeInColl(cdbI, &sc); err != nil {
+					log.Lvl1("failed to add to collections with error: " + err.Error())
+					continue clientTransactions
+				}
+			}
 			states = append(states, scs...)
 		}
 		cdbTemp = cdbI

--- a/omniledger/service/struct_test.go
+++ b/omniledger/service/struct_test.go
@@ -84,6 +84,40 @@ func TestCollectionDB(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, v, string(stored))
 	}
+
+	// Update
+	for k, v := range pairs {
+		pairs[k] = v + "-2"
+	}
+	for k, v := range pairs {
+		sc := &StateChange{
+			StateAction: Update,
+			ObjectID:    []byte(k),
+			Value:       []byte(v),
+			ContractID:  myContract,
+		}
+		require.Nil(t, cdb2.Store(sc), k)
+	}
+	for k, v := range pairs {
+		stored, contract, err := cdb2.GetValueContract([]byte(k))
+		require.Nil(t, err)
+		require.Equal(t, v, string(stored))
+		require.Equal(t, myContract, contract)
+	}
+
+	// Delete
+	for c := range pairs {
+		sc := &StateChange{
+			StateAction: Remove,
+			ObjectID:    []byte(c),
+			ContractID:  myContract,
+		}
+		require.Nil(t, cdb2.Store(sc))
+	}
+	for c := range pairs {
+		_, _, err := cdb2.GetValueContract([]byte(c))
+		require.NotNil(t, err, c)
+	}
 }
 
 // TODO: Test good case, bad add case, bad remove case

--- a/omniledger/service/transaction.go
+++ b/omniledger/service/transaction.go
@@ -162,8 +162,8 @@ func (instr Instruction) GetContractState(coll collection.Collection) (contractI
 	if err != nil {
 		return
 	}
-	contractID = string(cv[0].([]byte))
-	state = cv[1].([]byte)
+	contractID = string(cv[1].([]byte))
+	state = cv[0].([]byte)
 	return
 }
 


### PR DESCRIPTION
In the `createStateChanges` function, we update the collections so that the effect of every state change affects future state changes. Further, we add support the processing of actions Update and Delete. 